### PR TITLE
Handle missing release tag lookup

### DIFF
--- a/.github/workflows/build-and-sync.yml
+++ b/.github/workflows/build-and-sync.yml
@@ -248,10 +248,14 @@ jobs:
         run: |
           set -euo pipefail
 
-          EXISTING_SHA="$(
+          if EXISTING_SHA="$(
             gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${RELEASE_VERSION}" \
-              --jq '.object.sha' 2>/dev/null || true
-          )"
+              --jq '.object.sha' 2>/dev/null
+          )"; then
+            echo "Tag ${RELEASE_VERSION} already exists at ${EXISTING_SHA}."
+          else
+            EXISTING_SHA=""
+          fi
 
           if [[ -n "${EXISTING_SHA}" && "${EXISTING_SHA}" != "${GITHUB_SHA}" ]]; then
             echo "Tag ${RELEASE_VERSION} already points to ${EXISTING_SHA}, not ${GITHUB_SHA}."


### PR DESCRIPTION
## Root cause

The automatic release workflow queried the source tag through `gh api`. For a missing tag, GitHub returned a 404 JSON body on stdout. Because the command used `|| true` inside command substitution, that JSON body was assigned to `EXISTING_SHA` and was incorrectly treated as an existing tag pointing to the wrong commit.

## Fix

- branch on the actual `gh api` exit status
- retain the SHA only for a successful lookup
- explicitly clear `EXISTING_SHA` for a missing tag
- preserve the existing same-commit retry check

## Validation

- workflow YAML parsed successfully
- simulated 404 output is treated as a missing tag
- `git diff --check` passed

The prior run already built and synced the `v0.0.7` artifacts. After this reaches `main`, the workflow should reuse `v0.0.7` when appropriate and complete tag/release publication.