### PR TITLE
Add audited subject dropout workflow

### DIFF
--- a/eCRF_backend/datalad_repo.py
+++ b/eCRF_backend/datalad_repo.py
@@ -1369,6 +1369,139 @@ class DataladStudyRepo:
         self.save(p.dataset_path, f"case-e: upsert_entry study={study_id} entry={entry_id}")
         return entry
 
+    def save_entries_bulk(
+        self,
+        *,
+        study_id: int,
+        study_name: str,
+        form_version: int,
+        entries: List[Dict[str, Any]],
+        actor: str,
+        audit_label: Optional[str] = None,
+        user_id: Optional[int] = None,
+        actor_name: Optional[str] = None,
+        require_empty_slots: bool = True,
+    ) -> List[Dict[str, Any]]:
+        """Write a batch of entries under one dataset lock and one DataLad save."""
+        if not entries:
+            return []
+
+        p = self.ensure_dataset(study_id, study_name)
+
+        with dataset_lock(LockSpec(dataset_path=p.dataset_path)):
+            existing_rows = self.list_entries(study_id, study_name)
+            occupied_slots = set()
+            for row in existing_rows:
+                try:
+                    slot = (
+                        int(row.get("subject_index")),
+                        int(row.get("visit_index")),
+                        int(row.get("group_index")),
+                        int(row.get("form_version")),
+                    )
+                except (TypeError, ValueError):
+                    continue
+                occupied_slots.add(slot)
+
+            requested_slots = set()
+            normalized_entries = []
+            for item in entries:
+                normalized = {
+                    **item,
+                    "subject_index": int(item["subject_index"]),
+                    "visit_index": int(item["visit_index"]),
+                    "group_index": int(item["group_index"]),
+                }
+                slot = (
+                    normalized["subject_index"],
+                    normalized["visit_index"],
+                    normalized["group_index"],
+                    int(form_version),
+                )
+                if slot in requested_slots:
+                    raise ValueError(
+                        "Bulk import contains more than one row for the same subject, visit, group, and version"
+                    )
+                if require_empty_slots and slot in occupied_slots:
+                    raise ValueError(
+                        "Bulk import cannot overwrite a slot that already contains data"
+                    )
+                requested_slots.add(slot)
+                normalized_entries.append(normalized)
+
+            next_entry_id = self._next_entry_id_from_rows(existing_rows)
+            actor_payload = self._build_actor_payload(
+                actor=actor,
+                actor_name=actor_name,
+                user_id=user_id,
+            )
+            written = []
+
+            for item in normalized_entries:
+                entry_id = next_entry_id
+                next_entry_id += 1
+                now = local_now().isoformat()
+                entry = {
+                    "id": entry_id,
+                    "study_id": int(study_id),
+                    "subject_index": item["subject_index"],
+                    "visit_index": item["visit_index"],
+                    "group_index": item["group_index"],
+                    "form_version": int(form_version),
+                    "data": _deepcopy_json(item.get("data") or {}),
+                    "skipped_required_flags": _deepcopy_json(item.get("skipped_required_flags") or []),
+                    "progress_status": item.get("progress_status"),
+                    "progress_percentage": item.get("progress_percentage"),
+                    "progress_completed": item.get("progress_completed"),
+                    "progress_total": item.get("progress_total"),
+                    "progress_skipped": item.get("progress_skipped"),
+                    "created_at": now,
+                    "updated_at": now,
+                }
+
+                path = self._entry_path(
+                    p,
+                    form_version=form_version,
+                    subject_index=entry["subject_index"],
+                    visit_index=entry["visit_index"],
+                    group_index=entry["group_index"],
+                    entry_id=entry_id,
+                )
+                _json_dump(path, entry)
+
+                labels = self._resolve_subject_visit_group_labels(
+                    p,
+                    subject_index=entry["subject_index"],
+                    visit_index=entry["visit_index"],
+                    group_index=entry["group_index"],
+                    subject_raw=item.get("subject_raw"),
+                    visit_raw=item.get("visit_raw"),
+                    group_raw=item.get("group_raw"),
+                )
+                self._append_audit(
+                    p,
+                    action="entry_upserted",
+                    study_id=study_id,
+                    payload={
+                        "entry_id": entry_id,
+                        "subject_index": entry["subject_index"],
+                        "visit_index": entry["visit_index"],
+                        "group_index": entry["group_index"],
+                        "form_version": int(form_version),
+                        "ui_label": audit_label,
+                        **labels,
+                        **actor_payload,
+                    },
+                    subject_index=entry["subject_index"],
+                )
+                written.append(entry)
+
+        self.save(
+            p.dataset_path,
+            f"case-e: bulk_upsert_entries study={study_id} version={form_version} count={len(written)}",
+        )
+        return written
+
     def update_entry(
         self,
         *,

--- a/eCRF_backend/datalad_repo.py
+++ b/eCRF_backend/datalad_repo.py
@@ -2380,6 +2380,116 @@ class DataladStudyRepo:
             access_dir=canonical_dir / "access",
         )
 
+    def record_subject_status_event(
+        self,
+        *,
+        study_id: int,
+        study_name: str,
+        subject_index: int,
+        action: str,
+        payload: Dict[str, Any],
+    ) -> None:
+        p = self.ensure_dataset(study_id, study_name)
+        with dataset_lock(LockSpec(dataset_path=p.dataset_path)):
+            self._append_audit(
+                p,
+                action=action,
+                study_id=study_id,
+                payload=_deepcopy_json(payload or {}),
+                subject_index=subject_index,
+            )
+        self.save(p.dataset_path, f"case-e: {action} study={study_id} subject={subject_index}")
+
+    def delete_subject_active_data(
+        self,
+        *,
+        study_id: int,
+        study_name: str,
+        subject_index: int,
+        audit_payload: Dict[str, Any],
+    ) -> Dict[str, int]:
+        """Remove current subject data while retaining subject identity and audit history."""
+        p = self.ensure_dataset(study_id, study_name)
+        entry_paths: List[Path] = []
+        file_records: List[tuple[Path, Dict[str, Any]]] = []
+        share_records: List[tuple[Path, Dict[str, Any]]] = []
+
+        with dataset_lock(LockSpec(dataset_path=p.dataset_path)):
+            for path in p.entries_dir.rglob("entry_*.json"):
+                row = _json_load(path)
+                try:
+                    if row and int(row.get("subject_index")) == int(subject_index):
+                        entry_paths.append(path)
+                except (TypeError, ValueError):
+                    continue
+
+            for path in p.files_dir.rglob("file_*.json"):
+                row = _json_load(path)
+                try:
+                    if row and int(row.get("subject_index")) == int(subject_index):
+                        file_records.append((path, row))
+                except (TypeError, ValueError):
+                    continue
+
+            for path in p.shares_dir.glob("*.json"):
+                row = _json_load(path)
+                try:
+                    if row and int(row.get("subject_index")) == int(subject_index):
+                        share_records.append((path, row))
+                except (TypeError, ValueError):
+                    continue
+
+            files_root = Path(os.path.abspath(p.files_dir))
+            validated_payloads: List[Path] = []
+            for record_path, record in file_records:
+                storage_option = str(record.get("storage_option") or "").strip().lower()
+                stored_path = record.get("file_path")
+                if storage_option != "url" and stored_path:
+                    absolute_path = Path(os.path.abspath(p.dataset_path / str(stored_path)))
+                    try:
+                        absolute_path.relative_to(files_root)
+                        absolute_path.parent.resolve().relative_to(p.files_dir.resolve())
+                    except (ValueError, OSError) as exc:
+                        raise ValueError("Invalid file path outside study file storage") from exc
+                    if (absolute_path.exists() or absolute_path.is_symlink()) and not absolute_path.is_file() and not absolute_path.is_symlink():
+                        raise ValueError("Stored file path is not a file")
+                    validated_payloads.append(absolute_path)
+
+            for path in entry_paths:
+                path.unlink(missing_ok=True)
+
+            for absolute_path in validated_payloads:
+                if absolute_path.exists() or absolute_path.is_symlink():
+                    absolute_path.unlink()
+
+            for record_path, _record in file_records:
+                record_path.unlink(missing_ok=True)
+
+            for share_path, row in share_records:
+                row["max_uses"] = int(row.get("used_count") or 0)
+                row["status"] = "Invalidated by subject dropout"
+                row["revoked_at"] = local_now().isoformat()
+                _json_dump(share_path, row)
+
+            counts = {
+                "entries_deleted": len(entry_paths),
+                "files_deleted": len(file_records),
+                "shared_links_revoked": len(share_records),
+            }
+            self._append_audit(
+                p,
+                action="subject_dropped_delete_data",
+                study_id=study_id,
+                payload={**_deepcopy_json(audit_payload or {}), **counts},
+                subject_index=subject_index,
+            )
+
+        self.save(
+            p.dataset_path,
+            f"case-e: subject_dropped_delete_data study={study_id} subject={subject_index}",
+        )
+        return counts
+
     def _append_audit(
         self,
         p: StudyPaths,

--- a/eCRF_backend/forms_hybrid.py
+++ b/eCRF_backend/forms_hybrid.py
@@ -41,7 +41,6 @@ ACTIVE_SUBJECT_STATUS = "ACTIVE"
 SUBJECT_STATUS_FIELDS = {
     "status", "dropout_date", "dropout_reason", "dropout_other_reason",
     "dropped_at", "dropped_by", "dropped_by_name", "deletion_status",
-    "reactivated_at", "reactivated_by", "reactivation_reason",
 }
 
 
@@ -972,9 +971,6 @@ def drop_out_subject(
         "dropped_at": now_iso,
         "dropped_by": current_user.id,
         "dropped_by_name": _display_name(current_user),
-        "reactivated_at": None,
-        "reactivated_by": None,
-        "reactivation_reason": None,
     }
     audit_payload = {
         "subject_index": subject_index,
@@ -1070,61 +1066,6 @@ def drop_out_subject(
             pass
         raise HTTPException(status_code=500, detail="Subject data deletion did not complete. The subject remains blocked; contact an administrator.")
 
-
-@router.post("/studies/{study_id}/subjects/{subject_index}/reactivate")
-def reactivate_subject(
-    study_id: int,
-    subject_index: int,
-    payload: schemas.SubjectReactivateRequest,
-    db: Session = Depends(get_db),
-    current_user=Depends(get_current_user),
-):
-    meta = db.query(models.StudyMetadata).filter(models.StudyMetadata.id == study_id).first()
-    if not meta:
-        raise HTTPException(status_code=404, detail="Study not found")
-    if not _is_admin(current_user):
-        raise HTTPException(status_code=403, detail="Only administrators can reactivate subjects")
-    content_row = _get_content_row_or_404(db, study_id)
-    study_data = _deepcopy_json(content_row.study_data or {})
-    subject = _subject_from_study_data(study_data, subject_index)
-    if _subject_status(subject) != "DROPPED_DATA_RETAINED":
-        raise HTTPException(status_code=409, detail="Only data-retained dropout subjects can be reactivated")
-    subject_id = str(subject.get("id") or subject.get("subject_id") or f"Subject {subject_index + 1}").strip()
-    previous_status = _subject_status(subject)
-    subject.update({
-        "status": ACTIVE_SUBJECT_STATUS,
-        "reactivated_at": local_now().isoformat(),
-        "reactivated_by": current_user.id,
-        "reactivation_reason": str(payload.reason).strip(),
-    })
-    content_row.study_data = study_data
-    db.commit()
-    latest_tv = _latest_template_or_500(db, study_id)
-    _write_published_snapshot_to_datalad(
-        meta=meta,
-        study_data=study_data,
-        template_version=latest_tv.version,
-        template_schema=latest_tv.schema or {},
-        actor=_actor_identifier(current_user),
-        actor_name=_display_name(current_user),
-        user_id=current_user.id,
-        audit_label="Subject reactivated",
-    )
-    repo.record_subject_status_event(
-        study_id=study_id,
-        study_name=meta.study_name,
-        subject_index=subject_index,
-        action="subject_reactivated",
-        payload={
-            "subject_index": subject_index,
-            "subject_raw": subject_id,
-            "previous_status": previous_status,
-            "new_status": ACTIVE_SUBJECT_STATUS,
-            "reactivation_reason": str(payload.reason).strip(),
-            **repo._build_actor_payload(actor=_actor_identifier(current_user), actor_name=_display_name(current_user), user_id=current_user.id),
-        },
-    )
-    return {"ok": True, "subject_index": subject_index, "subject_id": subject_id, "status": ACTIVE_SUBJECT_STATUS}
 
 @router.get("/studies/{study_id}/files", response_model=List[schemas.FileOut])
 def read_files_for_study(

--- a/eCRF_backend/forms_hybrid.py
+++ b/eCRF_backend/forms_hybrid.py
@@ -37,6 +37,12 @@ TEMPLATE_DIR = (
 )
 
 ALLOWED_STUDY_STATUS = {"DRAFT", "PUBLISHED", "ARCHIVED"}
+ACTIVE_SUBJECT_STATUS = "ACTIVE"
+SUBJECT_STATUS_FIELDS = {
+    "status", "dropout_date", "dropout_reason", "dropout_other_reason",
+    "dropped_at", "dropped_by", "dropped_by_name", "deletion_status",
+    "reactivated_at", "reactivated_by", "reactivation_reason",
+}
 
 
 def _normalize_allowed_section_ids(section_ids: Optional[List[Any]]) -> List[str]:
@@ -88,6 +94,57 @@ def _is_admin(user) -> bool:
 def _assert_owner_or_admin(meta: models.StudyMetadata, user) -> None:
     if meta.created_by != user.id and not _is_admin(user):
         raise HTTPException(status_code=403, detail="Not authorized")
+
+
+def _subject_status(subject: Dict[str, Any]) -> str:
+    return str((subject or {}).get("status") or ACTIVE_SUBJECT_STATUS).strip().upper()
+
+
+def _subject_from_study_data(study_data: Dict[str, Any], subject_index: int) -> Dict[str, Any]:
+    subjects = (study_data or {}).get("subjects") or []
+    if not isinstance(subject_index, int) or subject_index < 0 or subject_index >= len(subjects):
+        raise HTTPException(status_code=404, detail="Subject not found")
+    subject = subjects[subject_index]
+    if not isinstance(subject, dict):
+        raise HTTPException(status_code=400, detail="Invalid subject record")
+    return subject
+
+
+def _assert_subject_active(study_data: Dict[str, Any], subject_index: int) -> Dict[str, Any]:
+    subject = _subject_from_study_data(study_data, int(subject_index))
+    if _subject_status(subject) != ACTIVE_SUBJECT_STATUS:
+        subject_id = subject.get("id") or subject.get("subject_id") or f"Subject {int(subject_index) + 1}"
+        date = subject.get("dropout_date") or "an earlier date"
+        raise HTTPException(
+            status_code=409,
+            detail=f'Subject "{subject_id}" was dropped out on {date}. Data entry is no longer permitted.',
+        )
+    return subject
+
+
+def _assert_subject_active_for_study(db: Session, study_id: int, subject_index: Optional[int]) -> None:
+    if subject_index is None:
+        return
+    content = _get_content_row_or_404(db, study_id)
+    _assert_subject_active(content.study_data or {}, int(subject_index))
+
+
+def _validate_subject_identity_and_status_update(old_sd: Dict[str, Any], new_sd: Dict[str, Any]) -> None:
+    old_subjects = (old_sd or {}).get("subjects") or []
+    new_subjects = (new_sd or {}).get("subjects") or []
+    if len(new_subjects) < len(old_subjects):
+        raise HTTPException(status_code=400, detail="Existing subjects cannot be removed")
+    for index, old_subject in enumerate(old_subjects):
+        new_subject = new_subjects[index] if index < len(new_subjects) else {}
+        old_id = str((old_subject or {}).get("id") or (old_subject or {}).get("subject_id") or "").strip()
+        new_id = str((new_subject or {}).get("id") or (new_subject or {}).get("subject_id") or "").strip()
+        if old_id != new_id:
+            raise HTTPException(status_code=400, detail="Existing subject IDs and positions cannot be changed")
+        if _subject_status(old_subject or {}) != ACTIVE_SUBJECT_STATUS and old_subject != new_subject:
+            raise HTTPException(status_code=409, detail="Dropped subjects cannot be modified")
+        for field in SUBJECT_STATUS_FIELDS:
+            if (old_subject or {}).get(field) != (new_subject or {}).get(field):
+                raise HTTPException(status_code=400, detail="Subject dropout status can only be changed with the dropout workflow")
 
 
 def _effective_study_permissions(db: Session, meta: models.StudyMetadata, user) -> Dict[str, bool]:
@@ -728,6 +785,7 @@ def update_study(
     content_row = _get_content_row_or_404(db, study_id)
     old_sd = _deepcopy_json(content_row.study_data or {})
     new_sd = _deepcopy_json(study_content.study_data or {})
+    _validate_subject_identity_and_status_update(old_sd, new_sd)
 
     incoming_status = _norm_status(getattr(study_metadata, "status", None)) or (meta.status or "PUBLISHED")
 
@@ -841,6 +899,233 @@ def publish_study(
         },
     }
 
+
+@router.get("/studies/{study_id}/subjects/dropout-summary")
+def subject_dropout_summary(
+    study_id: int,
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
+    meta = db.query(models.StudyMetadata).filter(models.StudyMetadata.id == study_id).first()
+    if not meta:
+        raise HTTPException(status_code=404, detail="Study not found")
+    _assert_has_study_permission(db, meta, current_user, required="view")
+    subjects = (_get_content_row_or_404(db, study_id).study_data or {}).get("subjects") or []
+    counts = {
+        "total_ever_enrolled": len(subjects),
+        "active": 0,
+        "dropped_data_retained": 0,
+        "dropped_data_deleted": 0,
+        "dropout_total": 0,
+        "by_reason": {},
+    }
+    for subject in subjects:
+        status_value = _subject_status(subject)
+        if status_value == ACTIVE_SUBJECT_STATUS:
+            counts["active"] += 1
+            continue
+        if status_value == "DROPPED_DATA_RETAINED":
+            counts["dropped_data_retained"] += 1
+        elif status_value == "DROPPED_DATA_DELETED":
+            counts["dropped_data_deleted"] += 1
+        if status_value.startswith("DROPPED_"):
+            counts["dropout_total"] += 1
+            reason = str((subject or {}).get("dropout_reason") or "Unspecified")
+            counts["by_reason"][reason] = int(counts["by_reason"].get(reason, 0)) + 1
+    total = counts["total_ever_enrolled"]
+    counts["dropout_percentage"] = round((counts["dropout_total"] / total) * 100, 2) if total else 0.0
+    return counts
+
+
+@router.post("/studies/{study_id}/subjects/{subject_index}/dropout")
+def drop_out_subject(
+    study_id: int,
+    subject_index: int,
+    payload: schemas.SubjectDropoutRequest,
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
+    meta = db.query(models.StudyMetadata).filter(models.StudyMetadata.id == study_id).first()
+    if not meta:
+        raise HTTPException(status_code=404, detail="Study not found")
+    _assert_owner_or_admin(meta, current_user)
+    try:
+        datetime.strptime(payload.dropout_date, "%Y-%m-%d")
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Dropout date must use YYYY-MM-DD")
+    other_reason = str(payload.other_reason or "").strip()
+    if payload.reason == "Other" and not other_reason:
+        raise HTTPException(status_code=400, detail="Other dropout reason is required")
+
+    content_row = _get_content_row_or_404(db, study_id)
+    study_data = _deepcopy_json(content_row.study_data or {})
+    subject = _assert_subject_active(study_data, subject_index)
+    subject_id = str(subject.get("id") or subject.get("subject_id") or f"Subject {subject_index + 1}").strip()
+    if payload.mode == "delete_data" and str(payload.confirmation_subject_id or "").strip() != subject_id:
+        raise HTTPException(status_code=400, detail="Enter the exact subject ID to confirm deletion")
+
+    now_iso = local_now().isoformat()
+    common = {
+        "dropout_date": payload.dropout_date,
+        "dropout_reason": payload.reason,
+        "dropout_other_reason": other_reason if payload.reason == "Other" else None,
+        "dropped_at": now_iso,
+        "dropped_by": current_user.id,
+        "dropped_by_name": _display_name(current_user),
+        "reactivated_at": None,
+        "reactivated_by": None,
+        "reactivation_reason": None,
+    }
+    audit_payload = {
+        "subject_index": subject_index,
+        "subject_raw": subject_id,
+        "previous_status": ACTIVE_SUBJECT_STATUS,
+        "dropout_date": payload.dropout_date,
+        "dropout_reason": payload.reason,
+        "dropout_other_reason": common["dropout_other_reason"],
+        "actor_role": "Administrator" if _is_admin(current_user) else "Study author",
+        **repo._build_actor_payload(
+            actor=_actor_identifier(current_user),
+            actor_name=_display_name(current_user),
+            user_id=current_user.id,
+        ),
+    }
+
+    if payload.mode == "keep_data":
+        subject.update({**common, "status": "DROPPED_DATA_RETAINED", "deletion_status": None})
+        content_row.study_data = study_data
+        db.commit()
+        latest_tv = _latest_template_or_500(db, study_id)
+        _write_published_snapshot_to_datalad(
+            meta=meta,
+            study_data=study_data,
+            template_version=latest_tv.version,
+            template_schema=latest_tv.schema or {},
+            actor=_actor_identifier(current_user),
+            actor_name=_display_name(current_user),
+            user_id=current_user.id,
+            audit_label="Subject dropped out — data retained",
+        )
+        repo.record_subject_status_event(
+            study_id=study_id,
+            study_name=meta.study_name,
+            subject_index=subject_index,
+            action="subject_dropped_keep_data",
+            payload={**audit_payload, "new_status": "DROPPED_DATA_RETAINED"},
+        )
+        return {"ok": True, "subject_index": subject_index, "subject_id": subject_id, "status": subject["status"]}
+
+    subject.update({**common, "status": "DROPOUT_DELETION_IN_PROGRESS", "deletion_status": "IN_PROGRESS"})
+    content_row.study_data = study_data
+    db.commit()
+    try:
+        counts = repo.delete_subject_active_data(
+            study_id=study_id,
+            study_name=meta.study_name,
+            subject_index=subject_index,
+            audit_payload={**audit_payload, "new_status": "DROPPED_DATA_DELETED"},
+        )
+        db.query(models.StudyEntryData).filter(
+            models.StudyEntryData.study_id == study_id,
+            models.StudyEntryData.subject_index == subject_index,
+        ).delete(synchronize_session=False)
+        db.query(models.File).filter(
+            models.File.study_id == study_id,
+            models.File.subject_index == subject_index,
+        ).delete(synchronize_session=False)
+        links = db.query(models.SharedFormAccess).filter(
+            models.SharedFormAccess.study_id == study_id,
+            models.SharedFormAccess.subject_index == subject_index,
+        ).all()
+        for link in links:
+            link.max_uses = int(link.used_count or 0)
+        subject.update({"status": "DROPPED_DATA_DELETED", "deletion_status": "COMPLETED"})
+        content_row.study_data = study_data
+        db.commit()
+        latest_tv = _latest_template_or_500(db, study_id)
+        _write_published_snapshot_to_datalad(
+            meta=meta,
+            study_data=study_data,
+            template_version=latest_tv.version,
+            template_schema=latest_tv.schema or {},
+            actor=_actor_identifier(current_user),
+            actor_name=_display_name(current_user),
+            user_id=current_user.id,
+            audit_label="Subject dropped out — active data deleted",
+        )
+        return {"ok": True, "subject_index": subject_index, "subject_id": subject_id, "status": subject["status"], **counts}
+    except Exception as exc:
+        subject.update({"status": "DROPOUT_DELETION_FAILED", "deletion_status": "FAILED"})
+        content_row.study_data = study_data
+        db.commit()
+        try:
+            repo.record_subject_status_event(
+                study_id=study_id,
+                study_name=meta.study_name,
+                subject_index=subject_index,
+                action="subject_data_deletion_failed",
+                payload={**audit_payload, "new_status": "DROPOUT_DELETION_FAILED", "error_type": type(exc).__name__},
+            )
+        except Exception:
+            pass
+        raise HTTPException(status_code=500, detail="Subject data deletion did not complete. The subject remains blocked; contact an administrator.")
+
+
+@router.post("/studies/{study_id}/subjects/{subject_index}/reactivate")
+def reactivate_subject(
+    study_id: int,
+    subject_index: int,
+    payload: schemas.SubjectReactivateRequest,
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
+    meta = db.query(models.StudyMetadata).filter(models.StudyMetadata.id == study_id).first()
+    if not meta:
+        raise HTTPException(status_code=404, detail="Study not found")
+    if not _is_admin(current_user):
+        raise HTTPException(status_code=403, detail="Only administrators can reactivate subjects")
+    content_row = _get_content_row_or_404(db, study_id)
+    study_data = _deepcopy_json(content_row.study_data or {})
+    subject = _subject_from_study_data(study_data, subject_index)
+    if _subject_status(subject) != "DROPPED_DATA_RETAINED":
+        raise HTTPException(status_code=409, detail="Only data-retained dropout subjects can be reactivated")
+    subject_id = str(subject.get("id") or subject.get("subject_id") or f"Subject {subject_index + 1}").strip()
+    previous_status = _subject_status(subject)
+    subject.update({
+        "status": ACTIVE_SUBJECT_STATUS,
+        "reactivated_at": local_now().isoformat(),
+        "reactivated_by": current_user.id,
+        "reactivation_reason": str(payload.reason).strip(),
+    })
+    content_row.study_data = study_data
+    db.commit()
+    latest_tv = _latest_template_or_500(db, study_id)
+    _write_published_snapshot_to_datalad(
+        meta=meta,
+        study_data=study_data,
+        template_version=latest_tv.version,
+        template_schema=latest_tv.schema or {},
+        actor=_actor_identifier(current_user),
+        actor_name=_display_name(current_user),
+        user_id=current_user.id,
+        audit_label="Subject reactivated",
+    )
+    repo.record_subject_status_event(
+        study_id=study_id,
+        study_name=meta.study_name,
+        subject_index=subject_index,
+        action="subject_reactivated",
+        payload={
+            "subject_index": subject_index,
+            "subject_raw": subject_id,
+            "previous_status": previous_status,
+            "new_status": ACTIVE_SUBJECT_STATUS,
+            "reactivation_reason": str(payload.reason).strip(),
+            **repo._build_actor_payload(actor=_actor_identifier(current_user), actor_name=_display_name(current_user), user_id=current_user.id),
+        },
+    )
+    return {"ok": True, "subject_index": subject_index, "subject_id": subject_id, "status": ACTIVE_SUBJECT_STATUS}
+
 @router.get("/studies/{study_id}/files", response_model=List[schemas.FileOut])
 def read_files_for_study(
     study_id: int,
@@ -901,6 +1186,7 @@ def upload_file(
 
     _assert_has_study_permission(db, meta, user, required="add_data")
     _assert_not_locked_by_other(meta, user)
+    _assert_subject_active_for_study(db, study_id, subject_index)
 
     modalities = _parse_modalities_json(modalities_json)
     latest_tv = _latest_template_or_500(db, study_id)
@@ -959,6 +1245,7 @@ def create_url_file(
 
     _assert_has_study_permission(db, meta, user, required="add_data")
     _assert_not_locked_by_other(meta, user)
+    _assert_subject_active_for_study(db, study_id, subject_index)
 
     modalities = _parse_modalities_json(modalities_json)
     latest_tv = _latest_template_or_500(db, study_id)
@@ -995,6 +1282,12 @@ def delete_study_file(
 
     _assert_has_study_permission(db, meta, user, required="add_data")
     _assert_not_locked_by_other(meta, user)
+
+    try:
+        existing_file = repo.get_file_record(study_id=study_id, study_name=meta.study_name, file_id=file_id)
+        _assert_subject_active_for_study(db, study_id, existing_file.get("subject_index"))
+    except FileNotFoundError:
+        return {"deleted": True, "file_id": file_id, "already_missing": True}
 
     try:
         deleted = repo.delete_file(
@@ -1036,6 +1329,7 @@ def shared_upload_file(
     meta = db.query(models.StudyMetadata).filter(models.StudyMetadata.id == access.study_id).first()
     if not meta:
         raise HTTPException(status_code=404, detail="Study not found")
+    _assert_subject_active_for_study(db, access.study_id, access.subject_index)
 
     # Locking disabled for now.
     # if bool(meta.is_locked):
@@ -1101,6 +1395,7 @@ def shared_delete_file(
     meta = db.query(models.StudyMetadata).filter(models.StudyMetadata.id == access.study_id).first()
     if not meta:
         raise HTTPException(status_code=404, detail="Study not found")
+    _assert_subject_active_for_study(db, access.study_id, access.subject_index)
 
     try:
         record = repo.get_file_record(
@@ -1201,6 +1496,7 @@ def save_study_data(
 
     _assert_has_study_permission(db, meta, current_user, required="add_data")
     _assert_not_locked_by_other(meta, current_user)
+    _assert_subject_active_for_study(db, study_id, payload.subject_index)
 
     if (meta.status or "PUBLISHED").upper().strip() != "PUBLISHED":
         raise HTTPException(status_code=400, detail="Data entry is only allowed for published studies")
@@ -1302,6 +1598,7 @@ def bulk_insert_data(
     entries = []
     for payload_entry in payload.entries:
         item = payload_entry.model_dump()
+        _assert_subject_active(content_row.study_data or {}, int(item["subject_index"]))
         item["skipped_required_flags"] = _flags_dict_to_list(
             item.get("skipped_required_flags"),
             selected_models,
@@ -1352,6 +1649,7 @@ def update_study_data_entry(
 
     _assert_has_study_permission(db, meta, user, required="add_data")
     _assert_not_locked_by_other(meta, user)
+    _assert_subject_active_for_study(db, study_id, payload.subject_index)
 
     if (meta.status or "PUBLISHED").upper().strip() != "PUBLISHED":
         raise HTTPException(status_code=400, detail="Data entry is only allowed for published studies")
@@ -1769,6 +2067,7 @@ def create_share_link(
 
     content_row = _get_content_row_or_404(db, payload.study_id)
     study_data = content_row.study_data or {}
+    _assert_subject_active(study_data, payload.subject_index)
 
     selected_models = study_data.get("selectedModels") or []
     assignments = study_data.get("assignments") or []
@@ -1852,6 +2151,8 @@ def access_shared_form(
     if access.expires_at < datetime.utcnow():
         raise HTTPException(403, "Link expired")
 
+    _assert_subject_active_for_study(db, access.study_id, access.subject_index)
+
     access.used_count += 1
     db.commit()
 
@@ -1882,6 +2183,7 @@ def access_shared_form(
         pass
 
     content_row = _get_content_row_or_404(db, access.study_id)
+    _assert_subject_active(content_row.study_data or {}, access.subject_index)
     filtered_study_data = _filter_shared_study_data_by_sections(
         content_row.study_data or {},
         access.allowed_section_ids,
@@ -1971,6 +2273,7 @@ def shared_upsert_data(
 
     content_row = _get_content_row_or_404(db, access.study_id)
     study_data = content_row.study_data or {}
+    _assert_subject_active(study_data, access.subject_index)
     selected_models = study_data.get("selectedModels") or []
 
     _validate_shared_payload_sections(

--- a/eCRF_backend/forms_hybrid.py
+++ b/eCRF_backend/forms_hybrid.py
@@ -128,6 +128,22 @@ def _assert_subject_active_for_study(db: Session, study_id: int, subject_index: 
     _assert_subject_active(content.study_data or {}, int(subject_index))
 
 
+def _assert_entry_subject_update_allowed(
+    study_data: Dict[str, Any],
+    target_entry: Dict[str, Any],
+    requested_subject_index: int,
+) -> None:
+    try:
+        target_subject_index = int(target_entry.get("subject_index"))
+        requested_index = int(requested_subject_index)
+    except (TypeError, ValueError):
+        raise HTTPException(status_code=400, detail="Invalid entry subject")
+
+    _assert_subject_active(study_data, target_subject_index)
+    if requested_index != target_subject_index:
+        raise HTTPException(status_code=409, detail="An existing entry cannot be moved to another subject")
+
+
 def _validate_subject_identity_and_status_update(old_sd: Dict[str, Any], new_sd: Dict[str, Any]) -> None:
     old_subjects = (old_sd or {}).get("subjects") or []
     new_subjects = (new_sd or {}).get("subjects") or []
@@ -1607,6 +1623,13 @@ def update_study_data_entry(
     if not target_entry:
         raise HTTPException(status_code=404, detail="Entry not found")
 
+    content_row = _get_content_row_or_404(db, study_id)
+    _assert_entry_subject_update_allowed(
+        content_row.study_data or {},
+        target_entry,
+        payload.subject_index,
+    )
+
     form_version = int(target_entry.get("form_version") or 1)
 
     try:
@@ -1637,7 +1660,6 @@ def update_study_data_entry(
             },
         )
 
-    content_row = _get_content_row_or_404(db, study_id)
     selected_models = ((content_row.study_data or {}).get("selectedModels") or [])
 
     try:

--- a/eCRF_backend/forms_hybrid.py
+++ b/eCRF_backend/forms_hybrid.py
@@ -1273,6 +1273,69 @@ def save_study_data(
         )
 
 
+@router.post("/studies/{study_id}/data/bulk")
+def bulk_insert_data(
+    study_id: int,
+    payload: schemas.BulkPayload = Body(...),
+    version: Optional[int] = Query(None),
+    create_bids: bool = Query(True),
+    audit_label: Optional[str] = Query(None),
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
+    meta = db.query(models.StudyMetadata).filter(models.StudyMetadata.id == study_id).first()
+    if not meta:
+        raise HTTPException(status_code=404, detail="Study not found")
+
+    _assert_has_study_permission(db, meta, current_user, required="add_data")
+    _assert_not_locked_by_other(meta, current_user)
+
+    if (meta.status or "PUBLISHED").upper().strip() != "PUBLISHED":
+        raise HTTPException(status_code=400, detail="Data entry is only allowed for published studies")
+
+    form_version = _resolve_form_version_or_400(db, study_id, version)
+    if not payload.entries:
+        return {"inserted": 0, "failed": 0, "errors": []}
+
+    content_row = _get_content_row_or_404(db, study_id)
+    selected_models = ((content_row.study_data or {}).get("selectedModels") or [])
+    entries = []
+    for payload_entry in payload.entries:
+        item = payload_entry.model_dump()
+        item["skipped_required_flags"] = _flags_dict_to_list(
+            item.get("skipped_required_flags"),
+            selected_models,
+        )
+        entries.append(item)
+
+    # create_bids is accepted for compatibility with the database-backed API.
+    # Hybrid mode always persists canonical entry data in the DataLad dataset.
+    _ = create_bids
+
+    try:
+        written = repo.save_entries_bulk(
+            study_id=study_id,
+            study_name=meta.study_name,
+            form_version=form_version,
+            entries=entries,
+            actor=_actor_identifier(current_user),
+            actor_name=_display_name(current_user),
+            user_id=current_user.id,
+            audit_label=audit_label or "Study Data Import",
+            require_empty_slots=True,
+        )
+    except ValueError as error:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "message": str(error),
+                "conflict": True,
+            },
+        )
+
+    return {"inserted": len(written), "failed": 0, "errors": []}
+
+
 @router.put("/studies/{study_id}/data_entries/{entry_id}", response_model=schemas.StudyDataEntryOut)
 def update_study_data_entry(
     study_id: int,

--- a/eCRF_backend/schemas.py
+++ b/eCRF_backend/schemas.py
@@ -318,6 +318,29 @@ class StudyDataConflictDetail(BaseModel):
     class Config:
         from_attributes = True
 
+
+class SubjectDropoutRequest(BaseModel):
+    mode: Literal["keep_data", "delete_data"]
+    dropout_date: str
+    reason: Literal[
+        "Withdrawal of consent",
+        "Lost to follow-up",
+        "Adverse event",
+        "Investigator decision",
+        "Protocol deviation",
+        "Non-compliance",
+        "Disease progression",
+        "Death",
+        "Administrative reason",
+        "Other",
+    ]
+    other_reason: Optional[str] = None
+    confirmation_subject_id: Optional[str] = None
+
+
+class SubjectReactivateRequest(BaseModel):
+    reason: constr(min_length=1, max_length=1000)
+
 class StudyDataEntryUpdate(BaseModel):
     data: Optional[Dict[str, Any]] = None
     skipped_required_flags: Optional[List[List[bool]]] = None

--- a/eCRF_backend/schemas.py
+++ b/eCRF_backend/schemas.py
@@ -338,9 +338,6 @@ class SubjectDropoutRequest(BaseModel):
     confirmation_subject_id: Optional[str] = None
 
 
-class SubjectReactivateRequest(BaseModel):
-    reason: constr(min_length=1, max_length=1000)
-
 class StudyDataEntryUpdate(BaseModel):
     data: Optional[Dict[str, Any]] = None
     skipped_required_flags: Optional[List[List[bool]]] = None

--- a/eCRF_frontend/src/components/ExportStudy.vue
+++ b/eCRF_frontend/src/components/ExportStudy.vue
@@ -378,6 +378,10 @@ export default {
           ? sd.subjects.map((x) => ({
               id: String(x.id || x.subjectId || x.label || "").trim(),
               group: String(x.group || "").trim(),
+              status: String(x.status || "ACTIVE").toUpperCase(),
+              dropout_date: x.dropout_date || null,
+              dropout_reason: x.dropout_reason || null,
+              dropout_other_reason: x.dropout_other_reason || null,
             }))
           : [];
         this.visits = Array.isArray(sd.visits) ? sd.visits : [];

--- a/eCRF_frontend/src/components/ImportStudy.vue
+++ b/eCRF_frontend/src/components/ImportStudy.vue
@@ -3,8 +3,40 @@
     <!-- STEP 1: Upload -->
     <section class="card">
       <h2>1) Upload file</h2>
-      <input type="file" accept=".csv,.tsv,.xlsx,.xls" @change="onFile" />
-      <div v-if="fileName" class="hint">Loaded: {{ fileName }} ({{ rowCount }} rows)</div>
+      <div class="upload-inputs">
+        <div class="upload-input-group">
+          <label class="upload-label">Study data</label>
+          <input type="file" accept=".csv,.tsv,.xlsx,.xls" @change="onFile" />
+          <div v-if="fileName" class="hint">Loaded: {{ fileName }} ({{ rowCount }} rows)</div>
+        </div>
+
+        <div class="upload-input-group">
+          <div class="schema-upload-heading">
+            <label class="upload-label">Field schema JSON <span class="muted">(optional)</span></label>
+            <button
+              type="button"
+              class="schema-info-button"
+              title="Field schema JSON example"
+              aria-label="Show field schema JSON example"
+              @click="showFieldSchemaInfo = true"
+            >
+              <i :class="icons.info"></i>
+            </button>
+          </div>
+          <input type="file" accept=".json,application/json" @change="onFieldSchemaFile" />
+          <div v-if="fieldSchemaFileName" class="schema-file-status">
+            <span>Loaded: {{ fieldSchemaFileName }}</span>
+            <button type="button" class="link schema-clear-button" @click="clearFieldSchema">Remove</button>
+          </div>
+          <div v-if="fieldSchemaAppliedCount" class="hint">
+            Schema matched {{ fieldSchemaAppliedCount }} column(s). Unlisted fields will be inferred.
+          </div>
+          <div v-if="fieldSchemaError" class="schema-error-row error">
+            <span>{{ fieldSchemaError }}</span>
+            <button type="button" class="link schema-clear-button" @click="clearFieldSchema">Ignore JSON</button>
+          </div>
+        </div>
+      </div>
 
       <div v-if="previewRows.length" class="table-scroll">
         <table class="preview">
@@ -375,6 +407,35 @@
         </button>
       </div>
     </section>
+
+    <div v-if="showFieldSchemaInfo" class="schema-modal-overlay" @click.self="showFieldSchemaInfo = false">
+      <div class="schema-modal" role="dialog" aria-modal="true" aria-labelledby="field-schema-title">
+        <div class="schema-modal-header">
+          <div>
+            <h3 id="field-schema-title">Field schema JSON example</h3>
+            <p class="muted">
+              Column names must exactly match the uploaded data headers. Fields omitted from this file use automatic inference.
+            </p>
+          </div>
+          <button type="button" class="schema-modal-close" aria-label="Close" @click="showFieldSchemaInfo = false">×</button>
+        </div>
+
+        <pre class="schema-example"><code>{{ fieldSchemaExampleText }}</code></pre>
+
+        <div class="schema-example-notes muted">
+          Supported types: text, textarea, number, checkbox, radio, date, time, select, and slider.
+          Use constraints for required fields, numeric ranges, steps, defaults, and date formats.
+        </div>
+
+        <div class="schema-modal-actions">
+          <button type="button" class="btn" @click="copyFieldSchemaExample">
+            {{ schemaCopyStatus || 'Copy JSON' }}
+          </button>
+          <button type="button" class="btn" @click="downloadFieldSchemaExample">Download example JSON</button>
+          <button type="button" class="btn primary" @click="showFieldSchemaInfo = false">Close</button>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -402,6 +463,12 @@ export default {
 
       // file/preview
       fileName: "",
+      fieldSchemaFileName: "",
+      fieldSchema: null,
+      fieldSchemaError: "",
+      fieldSchemaAppliedCount: 0,
+      showFieldSchemaInfo: false,
+      schemaCopyStatus: "",
       headers: [],
       rows: [],
       previewRows: [],
@@ -410,6 +477,7 @@ export default {
       // columns meta
       columns: [],
       columnMeta: new Map(),     // Map<label, {section, field, name}]
+      resolvedImportFields: new Map(),
 
       // mapping (metadata + subject + eCRF)
       mapping: {
@@ -457,15 +525,23 @@ export default {
       return this.store.state.user?.id || null;
     },
     otherFieldCandidates() {
+      const explicitFieldColumns = new Set(
+        (this.fieldSchema?.fields || []).map(field => field.column)
+      );
       const exclude = new Set(
         [
           this.mapping.subject.idCol,
           this.mapping.group.nameCol,
           this.mapping.visit.nameCol,
-          this.mapping.subject.dateCol,
+          explicitFieldColumns.has(this.mapping.subject.dateCol)
+            ? ""
+            : this.mapping.subject.dateCol,
         ].filter(Boolean)
       );
       return this.headers.filter(h => !exclude.has(h));
+    },
+    fieldSchemaExampleText() {
+      return JSON.stringify(this.fieldSchemaExampleObject(), null, 2);
     },
   },
   watch: {
@@ -556,6 +632,392 @@ export default {
       }
     },
 
+    onFieldSchemaFile(e) {
+      const file = e.target.files?.[0];
+      if (!file) return;
+
+      const reader = new FileReader();
+      reader.onload = (event) => {
+        try {
+          const parsed = JSON.parse(String(event.target?.result || ""));
+          this.fieldSchema = this.normalizeFieldSchemaDocument(parsed);
+          this.fieldSchemaFileName = file.name;
+          this.fieldSchemaError = "";
+          this.structureReady = false;
+          this.applyFieldSchemaToCurrentHeaders();
+        } catch (error) {
+          this.fieldSchema = null;
+          this.fieldSchemaFileName = "";
+          this.fieldSchemaAppliedCount = 0;
+          this.fieldSchemaError = error?.message || "Could not parse field schema JSON.";
+        } finally {
+          e.target.value = "";
+        }
+      };
+      reader.onerror = () => {
+        this.fieldSchemaError = "Could not read field schema JSON.";
+        e.target.value = "";
+      };
+      reader.readAsText(file);
+    },
+
+    normalizeFieldSchemaDocument(document) {
+      if (!document || typeof document !== "object" || Array.isArray(document)) {
+        throw new Error("Field schema JSON must contain an object.");
+      }
+      if (!Array.isArray(document.fields) || !document.fields.length) {
+        throw new Error('Field schema JSON must contain a non-empty "fields" array.');
+      }
+
+      const typeAliases = {
+        string: "text",
+        integer: "number",
+        decimal: "number",
+        boolean: "checkbox",
+        dropdown: "select",
+      };
+      const supportedTypes = new Set([
+        "text", "textarea", "number", "checkbox", "radio",
+        "date", "time", "select", "slider",
+      ]);
+      const seenColumns = new Set();
+      const shorthandConstraints = [
+        "required", "readonly", "min", "max", "step", "minLength", "maxLength",
+        "dateFormat", "minDate", "maxDate", "defaultValue", "allowMultiple",
+      ];
+
+      const fields = document.fields.map((rawField, index) => {
+        if (!rawField || typeof rawField !== "object" || Array.isArray(rawField)) {
+          throw new Error(`Field schema item ${index + 1} must be an object.`);
+        }
+
+        const column = String(rawField.column || "").trim();
+        if (!column) throw new Error(`Field schema item ${index + 1} is missing "column".`);
+        if (seenColumns.has(column)) throw new Error(`Field schema contains duplicate column "${column}".`);
+        seenColumns.add(column);
+
+        const requestedType = String(rawField.type || "").trim().toLowerCase();
+        const type = typeAliases[requestedType] || requestedType;
+        if (!supportedTypes.has(type)) {
+          throw new Error(`Unsupported type "${rawField.type || ""}" for column "${column}".`);
+        }
+
+        if (rawField.options != null && !Array.isArray(rawField.options)) {
+          throw new Error(`Options for column "${column}" must be an array.`);
+        }
+        if (
+          rawField.constraints != null &&
+          (typeof rawField.constraints !== "object" || Array.isArray(rawField.constraints))
+        ) {
+          throw new Error(`Constraints for column "${column}" must be an object.`);
+        }
+
+        const constraints = { ...(rawField.constraints || {}) };
+        shorthandConstraints.forEach((key) => {
+          if (rawField[key] !== undefined && constraints[key] === undefined) {
+            constraints[key] = rawField[key];
+          }
+        });
+
+        return {
+          column,
+          type,
+          section: String(rawField.section || "").trim(),
+          name: String(rawField.name || "").trim(),
+          label: String(rawField.label || "").trim(),
+          description: String(rawField.description || ""),
+          placeholder: String(rawField.placeholder || ""),
+          options: Array.isArray(rawField.options) ? rawField.options : [],
+          constraints,
+        };
+      });
+
+      return { version: document.version || 1, fields };
+    },
+
+    applyFieldSchemaToCurrentHeaders() {
+      this.fieldSchemaAppliedCount = 0;
+      if (!this.fieldSchema) {
+        this.fieldSchemaError = "";
+        return;
+      }
+      if (!this.headers.length) return;
+
+      const headerSet = new Set(this.headers);
+      const unknownColumns = this.fieldSchema.fields
+        .map(field => field.column)
+        .filter(column => !headerSet.has(column));
+      if (unknownColumns.length) {
+        this.fieldSchemaError = `Schema column(s) not found in the data file: ${unknownColumns.join(", ")}`;
+        return;
+      }
+
+      this.fieldSchemaError = "";
+      const structuralColumns = new Set([
+        this.mapping.subject.idCol,
+        this.mapping.group.nameCol,
+        this.mapping.visit.nameCol,
+      ].filter(Boolean));
+      const explicitColumns = this.fieldSchema.fields
+        .map(field => field.column)
+        .filter(column => !structuralColumns.has(column));
+      this.mapping.otherCols = Array.from(new Set([
+        ...this.mapping.otherCols,
+        ...explicitColumns,
+      ]));
+      this.fieldSchemaAppliedCount = this.fieldSchema.fields.length;
+      this.otherAllSelected = this.otherFieldCandidates.length > 0 &&
+        this.otherFieldCandidates.every(column => this.mapping.otherCols.includes(column));
+    },
+
+    clearFieldSchema() {
+      const mappedDateColumn = this.mapping.subject.dateCol;
+      this.fieldSchema = null;
+      this.fieldSchemaFileName = "";
+      this.fieldSchemaError = "";
+      this.fieldSchemaAppliedCount = 0;
+      this.schemaCopyStatus = "";
+      if (mappedDateColumn) {
+        this.mapping.otherCols = this.mapping.otherCols.filter(column => column !== mappedDateColumn);
+      }
+      this.otherAllSelected = false;
+      this.structureReady = false;
+    },
+
+    fieldSchemaExampleObject() {
+      return {
+        version: 1,
+        fields: [
+          {
+            column: "Site Code",
+            name: "site_code",
+            label: "Site Code",
+            section: "Visit Information",
+            description: "Identifier of the study site.",
+            placeholder: "SITE-01",
+            type: "text",
+            constraints: {
+              required: true,
+              readonly: false,
+              helpText: "Use the assigned site code.",
+              placeholder: "SITE-01",
+              defaultValue: "",
+              minLength: 7,
+              maxLength: 12,
+              pattern: "^SITE-[0-9]+$",
+              transform: "uppercase",
+            },
+          },
+          {
+            column: "Clinical Notes",
+            name: "clinical_notes",
+            label: "Clinical Notes",
+            section: "Visit Information",
+            description: "Free-text clinical observations.",
+            placeholder: "Enter relevant observations",
+            type: "textarea",
+            constraints: {
+              required: false,
+              readonly: false,
+              helpText: "Do not enter directly identifying information.",
+              placeholder: "Enter relevant observations",
+              defaultValue: "",
+              minLength: 0,
+              maxLength: 2000,
+              pattern: ".*",
+              transform: "none",
+            },
+          },
+          {
+            column: "Age (years)",
+            name: "age_years",
+            label: "Age (years)",
+            section: "Demographics",
+            description: "Age at assessment in completed years.",
+            placeholder: "18",
+            type: "number",
+            constraints: {
+              required: true,
+              readonly: false,
+              helpText: "Enter whole years.",
+              placeholder: "18",
+              defaultValue: "",
+              min: 0,
+              max: 120,
+              step: 1,
+              integerOnly: true,
+              minDigits: 1,
+              maxDigits: 3,
+            },
+          },
+          {
+            column: "Informed Consent",
+            name: "informed_consent",
+            label: "Informed Consent",
+            section: "Eligibility",
+            description: "Whether informed consent was obtained.",
+            type: "checkbox",
+            constraints: {
+              required: true,
+              readonly: false,
+              helpText: "Checked means consent was obtained.",
+              defaultValue: false,
+            },
+          },
+          {
+            column: "Symptoms",
+            name: "symptoms",
+            label: "Symptoms",
+            section: "Assessment",
+            description: "Select all symptoms reported by the subject.",
+            placeholder: "Select one or more symptoms",
+            type: "radio",
+            options: ["None", "Mild", "Moderate", "Severe"],
+            constraints: {
+              required: false,
+              readonly: false,
+              helpText: "The dominant option None clears other selections.",
+              placeholder: "Select one or more symptoms",
+              defaultValue: ["None"],
+              allowMultiple: true,
+              dominantOptions: ["None"],
+            },
+          },
+          {
+            column: "Assessment Date",
+            name: "assessment_date",
+            label: "Assessment Date",
+            section: "Visit Information",
+            description: "Date on which the assessment occurred.",
+            placeholder: "yyyy-MM-dd",
+            type: "date",
+            constraints: {
+              required: true,
+              readonly: false,
+              helpText: "Use ISO date format.",
+              placeholder: "yyyy-MM-dd",
+              defaultValue: "2025-01-01",
+              dateFormat: "yyyy-MM-dd",
+              minDate: "2020-01-01",
+              maxDate: "2030-12-31",
+            },
+          },
+          {
+            column: "Assessment Time",
+            name: "assessment_time",
+            label: "Assessment Time",
+            section: "Visit Information",
+            description: "Time at which the assessment occurred.",
+            placeholder: "HH:mm",
+            type: "time",
+            constraints: {
+              required: false,
+              readonly: false,
+              helpText: "Use 24-hour time.",
+              placeholder: "HH:mm",
+              defaultValue: "09:00",
+              hourCycle: "24",
+              minTime: "00:00",
+              maxTime: "23:59",
+              step: 60,
+            },
+          },
+          {
+            column: "Sex",
+            name: "sex",
+            label: "Sex",
+            section: "Demographics",
+            description: "Recorded sex category.",
+            placeholder: "Select a value",
+            type: "select",
+            options: ["Female", "Male", "Other"],
+            constraints: {
+              required: true,
+              readonly: false,
+              helpText: "Choose one option.",
+              placeholder: "Select a value",
+              defaultValue: "Other",
+            },
+          },
+          {
+            column: "Pain Score",
+            name: "pain_score",
+            label: "Pain Score",
+            section: "Assessment",
+            description: "Pain intensity from 0 to 10.",
+            type: "slider",
+            constraints: {
+              required: false,
+              readonly: false,
+              helpText: "0 means no pain and 10 means worst pain.",
+              mode: "slider",
+              percent: false,
+              min: 0,
+              max: 10,
+              step: 1,
+              showTicks: true,
+              marks: [
+                { value: 0, label: "No pain" },
+                { value: 5, label: "Moderate" },
+                { value: 10, label: "Worst pain" },
+              ],
+            },
+          },
+          {
+            column: "Quality Rating",
+            name: "quality_rating",
+            label: "Quality Rating",
+            section: "Assessment",
+            description: "Example of the Likert variant of a slider field.",
+            type: "slider",
+            constraints: {
+              required: false,
+              readonly: false,
+              helpText: "Choose one point on the scale.",
+              mode: "linear",
+              min: 1,
+              max: 5,
+              leftLabel: "Very poor",
+              rightLabel: "Excellent",
+            },
+          },
+        ],
+      };
+    },
+
+    async copyFieldSchemaExample() {
+      try {
+        if (navigator.clipboard && window.isSecureContext) {
+          await navigator.clipboard.writeText(this.fieldSchemaExampleText);
+        } else {
+          const textarea = document.createElement("textarea");
+          textarea.value = this.fieldSchemaExampleText;
+          textarea.style.position = "fixed";
+          textarea.style.opacity = "0";
+          document.body.appendChild(textarea);
+          textarea.select();
+          document.execCommand("copy");
+          textarea.remove();
+        }
+        this.schemaCopyStatus = "Copied";
+      } catch {
+        this.schemaCopyStatus = "Copy failed";
+      }
+      window.setTimeout(() => { this.schemaCopyStatus = ""; }, 1600);
+    },
+
+    downloadFieldSchemaExample() {
+      const blob = new Blob([`${this.fieldSchemaExampleText}\n`], { type: "application/json;charset=utf-8" });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = "field-schema.example.json";
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      URL.revokeObjectURL(url);
+    },
+
     ingestFromMatrix(matrix) {
       if (!Array.isArray(matrix) || !matrix.length) {
         this.saveError = "No rows found.";
@@ -626,6 +1088,8 @@ export default {
       if (!this.studyMeta.name) {
         this.studyMeta.name = (this.fileName || "Imported Study").replace(/\.(csv|tsv|xlsx|xls)$/i, "");
       }
+
+      this.applyFieldSchemaToCurrentHeaders();
     },
 
     buildRowObjects(dataRows, cols) {
@@ -662,6 +1126,43 @@ export default {
         .toLowerCase();
     },
     safeStr(v) { return v == null ? "" : String(v).trim(); },
+
+    async postImportedEntry(studyId, item) {
+      const headers = { Authorization: `Bearer ${this.token}` };
+      let expectedRevisionToken = null;
+
+      try {
+        const { data: slot } = await axios.get(
+          `/forms/studies/${studyId}/slot-data`,
+          {
+            headers,
+            params: {
+              subject_index: item.subject_index,
+              visit_index: item.visit_index,
+              group_index: item.group_index,
+            },
+          }
+        );
+        expectedRevisionToken = String(slot?.revision_token ?? "");
+      } catch (error) {
+        // The legacy database backend has no slot-data endpoint and does not
+        // require revision tokens. Preserve compatibility with that backend.
+        if (error?.response?.status !== 404 && error?.response?.status !== 405) {
+          throw error;
+        }
+      }
+
+      const params = { audit_label: "Study Data Import" };
+      if (expectedRevisionToken !== null) {
+        params.expected_revision_token = expectedRevisionToken;
+      }
+
+      await axios.post(
+        `/forms/studies/${studyId}/data`,
+        item,
+        { headers, params }
+      );
+    },
 
     firstNonEmptyFromColumn(col) {
       if (!col) return "";
@@ -733,22 +1234,49 @@ export default {
     },
 
     // ---------- eCRF model building ----------
+    isStrictDateValue(value) {
+      const text = String(value ?? "").trim();
+      let match = text.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+      let year, month, day;
+      if (match) {
+        year = Number(match[1]);
+        month = Number(match[2]);
+        day = Number(match[3]);
+      } else {
+        match = text.match(/^(\d{2})[.-](\d{2})[.-](\d{4})$/);
+        if (!match) return false;
+        day = Number(match[1]);
+        month = Number(match[2]);
+        year = Number(match[3]);
+      }
+
+      const date = new Date(Date.UTC(year, month - 1, day));
+      return date.getUTCFullYear() === year &&
+        date.getUTCMonth() === month - 1 &&
+        date.getUTCDate() === day;
+    },
+
     inferFieldType(samples) {
       let nums = 0, dates = 0, bools = 0, total = 0;
       for (const v of samples) {
         if (v == null || v === "") continue;
         total++;
         if (!isNaN(Number(v))) { nums++; continue; }
-        const d = new Date(v); if (!isNaN(d.getTime())) { dates++; continue; }
         if (["true","false","yes","no","y","n","0","1"].includes(String(v).toLowerCase())) { bools++; continue; }
+        if (this.isStrictDateValue(v)) { dates++; continue; }
       }
       if (total && nums === total) return "number";
       if (total && dates === total) return "date";
-      if (total && bools === total) return "boolean";
+      if (total && bools === total) return "checkbox";
       return "text";
     },
 
+    fieldSchemaDefinitionForColumn(column) {
+      return (this.fieldSchema?.fields || []).find(field => field.column === column) || null;
+    },
+
     buildSelectedModels() {
+      this.resolvedImportFields = new Map();
       const samplesByLabel = {};
       for (const k of this.mapping.otherCols) samplesByLabel[k] = [];
       for (const r of this.rows.slice(0, 200)) {
@@ -759,17 +1287,22 @@ export default {
       for (const label of this.mapping.otherCols) {
         const meta = this.columnMeta.get(label);
         if (!meta) continue;
-        const type = this.inferFieldType(samplesByLabel[label] || []);
-        const arr = bySection.get(meta.section) || [];
-        arr.push({
-          name: meta.name,
-          label: meta.field,
-          description: "",
-          type, options: [],
-          constraints: { required: false },
-          placeholder: ""
-        });
-        bySection.set(meta.section, arr);
+        const definition = this.fieldSchemaDefinitionForColumn(label);
+        const section = definition?.section || meta.section;
+        const type = definition?.type || this.inferFieldType(samplesByLabel[label] || []);
+        const arr = bySection.get(section) || [];
+        const field = {
+          name: definition?.name || meta.name,
+          label: definition?.label || meta.field,
+          description: definition?.description || "",
+          type,
+          options: definition?.options || [],
+          constraints: { required: false, ...(definition?.constraints || {}) },
+          placeholder: definition?.placeholder || ""
+        };
+        arr.push(field);
+        this.resolvedImportFields.set(label, { section, field });
+        bySection.set(section, arr);
       }
 
       const models = [];
@@ -813,10 +1346,41 @@ export default {
       for (const [label, val] of Object.entries(flatData || {})) {
         const meta = this.columnMeta.get(label);
         if (!meta) continue;
-        if (!out[meta.section]) out[meta.section] = {};
-        out[meta.section][meta.name] = val;
+        const resolved = this.resolvedImportFields.get(label);
+        const section = resolved?.section || meta.section;
+        const field = resolved?.field || { name: meta.name, type: "text", constraints: {} };
+        if (!out[section]) out[section] = {};
+        out[section][field.name || meta.name] = this.normalizeImportedFieldValue(val, field);
       }
       return out;
+    },
+
+    normalizeImportedFieldValue(value, field) {
+      if (value == null || value === "") return value;
+      const type = String(field?.type || "text").toLowerCase();
+      const text = String(value).trim();
+
+      if (type === "number" || type === "slider") {
+        const number = Number(text.replace(/,/g, "."));
+        return Number.isFinite(number) ? number : value;
+      }
+
+      if (type === "checkbox") {
+        const normalized = text.toLowerCase();
+        if (["true", "yes", "y", "1", "checked"].includes(normalized)) return true;
+        if (["false", "no", "n", "0", "unchecked"].includes(normalized)) return false;
+        return value;
+      }
+
+      if (
+        (type === "select" || type === "radio") &&
+        field?.constraints?.allowMultiple &&
+        typeof value === "string"
+      ) {
+        return value.split(",").map(item => item.trim()).filter(Boolean);
+      }
+
+      return value;
     },
 
     // ---------- Structure inference ----------
@@ -825,6 +1389,11 @@ export default {
       this.failures = [];
       this.successStudyId = null;
       this.structureReady = false;
+
+      if (this.fieldSchemaError) {
+        this.saveError = "Please fix or remove the field schema JSON before inferring the study structure.";
+        return;
+      }
 
       if (!this.mapping.subject.idCol) {
         this.saveError = "Please map Subject ID column.";
@@ -1017,13 +1586,7 @@ export default {
           );
           return resp.data;
         };
-        const postOne = async (item) => {
-          await axios.post(
-            `/forms/studies/${studyId}/data`,
-            item,
-            { headers: { Authorization: `Bearer ${this.token}` } }
-          );
-        };
+        const postOne = async (item) => this.postImportedEntry(studyId, item);
 
         const CHUNK_SIZE = 1000;
 
@@ -1076,6 +1639,7 @@ export default {
       this.rowCount = 0;
       this.columns = [];
       this.columnMeta = new Map();
+      this.resolvedImportFields = new Map();
       this.mapping.subject = { idCol: "", dateCol: "" };
       this.mapping.group = { nameCol: "", cols: {}, fixed: {} };
       this.mapping.visit = { nameCol: "", cols: {}, fixed: {} };
@@ -1091,6 +1655,8 @@ export default {
       this.failures = [];
       this.saveError = "";
       this.successStudyId = null;
+      this.fieldSchemaError = "";
+      this.fieldSchemaAppliedCount = 0;
 
       // keep default OFF on new file
       this.createBidsOnImport = false;
@@ -1135,6 +1701,128 @@ export default {
   background:#fafafa;
   min-width: 0;
   max-width: 100%;
+}
+
+.upload-inputs {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(260px, 1fr));
+  gap: 16px;
+  align-items: start;
+}
+
+.upload-input-group {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  min-width: 0;
+  padding: 12px;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  background: #fff;
+}
+
+.upload-label {
+  font-weight: 600;
+  color: #333;
+}
+
+.schema-upload-heading,
+.schema-file-status {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.schema-info-button,
+.schema-modal-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  background: transparent;
+  color: #2f6fed;
+  cursor: pointer;
+}
+
+.schema-info-button {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+}
+
+.schema-info-button:hover {
+  background: #eff6ff;
+}
+
+.schema-clear-button {
+  padding: 0;
+}
+
+.schema-modal-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 5000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: rgba(15, 23, 42, 0.55);
+}
+
+.schema-modal {
+  width: min(820px, 100%);
+  max-height: calc(100vh - 48px);
+  overflow: auto;
+  padding: 20px;
+  border-radius: 12px;
+  background: #fff;
+  box-shadow: 0 24px 70px rgba(15, 23, 42, 0.28);
+}
+
+.schema-modal-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.schema-modal-header h3 {
+  margin: 0 0 6px;
+}
+
+.schema-modal-close {
+  flex: 0 0 auto;
+  width: 34px;
+  height: 34px;
+  color: #4b5563;
+  font-size: 26px;
+}
+
+.schema-example {
+  max-height: 420px;
+  overflow: auto;
+  margin: 16px 0 10px;
+  padding: 14px;
+  border: 1px solid #dbe3ef;
+  border-radius: 8px;
+  background: #f8fafc;
+  color: #172033;
+  font-size: 12px;
+  line-height: 1.5;
+  white-space: pre;
+}
+
+.schema-example-notes {
+  line-height: 1.5;
+}
+
+.schema-modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 16px;
+  flex-wrap: wrap;
 }
 
 .grid { display:grid; grid-template-columns: repeat(2, minmax(220px, 1fr)); gap:14px; min-width:0; }
@@ -1191,6 +1879,12 @@ input, select { padding:10px; border:1px solid #ddd; border-radius:8px; }
 .success { margin-top: 12px; }
 .link { background:none; border:none; color:#2f6fed; cursor:pointer; text-decoration: underline; }
 .hint { color:#555; margin-top:6px; }
+
+@media (max-width: 760px) {
+  .upload-inputs {
+    grid-template-columns: 1fr;
+  }
+}
 
 /* schema mapping grid */
 .schema-grid { display: grid; grid-template-columns: 1fr; gap: 10px; margin-top: 8px; min-width:0; }

--- a/eCRF_frontend/src/components/SelectionMatrixView.vue
+++ b/eCRF_frontend/src/components/SelectionMatrixView.vue
@@ -76,6 +76,30 @@
           >
             + Add subjects
           </button>
+
+          <button
+            v-if="canManageSubjectDropout"
+            type="button"
+            class="btn-dropout-subject"
+            @click="$emit('dropout-subject')"
+          >
+            <i class="fas fa-user-slash"></i> Drop out subject
+          </button>
+
+          <label class="subject-status-filter">
+            Subject status
+            <select v-model="subjectStatusFilter">
+              <option value="active_and_retained">Active + retained dropouts</option>
+              <option value="active">Active subjects</option>
+              <option value="retained">Dropped — data retained</option>
+              <option value="deleted">Dropped — data deleted</option>
+              <option value="all">All subjects</option>
+            </select>
+          </label>
+
+          <span class="dropout-summary" title="Subjects ever enrolled / active / dropped out">
+            Enrolled {{ subjectCounts.total }} · Active {{ subjectCounts.active }} · Dropped {{ subjectCounts.dropped }}
+          </span>
         </div>
 
         <!-- Info icon MUST be extreme right -->
@@ -118,18 +142,30 @@
           </thead>
           <tbody>
             <tr
-              v-for="(subject, sIdx) in subjects"
-              :key="'sv-row-'+sIdx"
-              :ref="el => setSubjectRowRef(el, sIdx)"
+              v-for="item in displayedSubjects"
+              :key="'sv-row-'+item.sIdx"
+              :ref="el => setSubjectRowRef(el, item.sIdx)"
               class="subject-row"
               :class="{
-                'subject-row-search-match': isSearchMatchedSubject(sIdx),
-                'subject-row-search-active': activeMatchedSubjectIndex === sIdx
+                'subject-row-search-match': isSearchMatchedSubject(item.sIdx),
+                'subject-row-search-active': activeMatchedSubjectIndex === item.sIdx,
+                'subject-row-dropped': isDropped(item.subject),
+                'subject-row-deleted': subjectStatus(item.subject) === 'DROPPED_DATA_DELETED'
               }"
             >
 
               <td class="subject-cell" :style="subjectColStyle">
-                {{ subject.id }}
+                {{ item.subject.id }}
+                <span v-if="isDropped(item.subject)" class="dropout-badge" :title="dropoutTitle(item.subject)">
+                  <i class="fas fa-user-slash"></i>
+                  {{ subjectStatus(item.subject) === 'DROPPED_DATA_DELETED' ? 'Data deleted' : 'Dropped out' }}
+                </span>
+                <button
+                  v-if="isAdmin && subjectStatus(item.subject) === 'DROPPED_DATA_RETAINED'"
+                  type="button"
+                  class="reactivate-btn"
+                  @click="$emit('reactivate-subject', item.sIdx)"
+                >Reactivate</button>
               </td>
 
 
@@ -137,24 +173,26 @@
                 v-if="showGroupColumn"
                 class="group-cell"
               >
-                {{ subject.group || "—" }}
+                {{ item.subject.group || "—" }}
               </td>
 
               <td
                 v-for="vIdx in displayedVisitIndices"
-                :key="'visit-td-' + sIdx + '-' + vIdx"
+                :key="'visit-td-' + item.sIdx + '-' + vIdx"
                 class="visit-cell"
                 :style="visitColStyle"
               >
                 <button
                   class="select-btn"
-                  :class="statusClass(sIdx, vIdx)"
-                  :style="progressStyle(sIdx, vIdx)"
-                  @click="$emit('select-cell', sIdx, vIdx)"
+                  :class="statusClass(item.sIdx, vIdx)"
+                  :style="progressStyle(item.sIdx, vIdx)"
+                  :disabled="isDropped(item.subject)"
+                  :title="isDropped(item.subject) ? dropoutTitle(item.subject) : ''"
+                  @click="$emit('select-cell', item.sIdx, vIdx)"
                 >
                   <span class="select-btn-fill"></span>
                   <span class="select-btn-label">
-                    {{ progressLabel(sIdx, vIdx) || "Select" }}
+                    {{ isDropped(item.subject) ? 'Dropped out' : (progressLabel(item.sIdx, vIdx) || "Select") }}
                   </span>
                 </button>
               </td>
@@ -204,10 +242,14 @@ export default {
     infoIcon: { type: String, default: "fas fa-info-circle" },
 
     showGroupColumn: { type: Boolean, default: false },
+    canManageSubjectDropout: { type: Boolean, default: false },
+    isAdmin: { type: Boolean, default: false },
   },
   emits: [
     "update:selectedVisitIndex",
     "add-subjects",
+    "dropout-subject",
+    "reactivate-subject",
     "select-cell",
     "open-status-legend",
   ],
@@ -218,6 +260,7 @@ export default {
       matchedSubjectIndices: [],
       activeMatchPosition: 0,
       subjectRowRefs: {},
+      subjectStatusFilter: "active_and_retained",
     };
   },
 
@@ -226,9 +269,38 @@ export default {
       if (!this.matchedSubjectIndices.length) return null;
       return this.matchedSubjectIndices[this.activeMatchPosition] ?? null;
     },
+    displayedSubjects() {
+      return (this.subjects || []).map((subject, sIdx) => ({ subject, sIdx })).filter(({ subject }) => {
+        const status = this.subjectStatus(subject);
+        if (this.subjectStatusFilter === "all") return true;
+        if (this.subjectStatusFilter === "active") return status === "ACTIVE";
+        if (this.subjectStatusFilter === "retained") return status === "DROPPED_DATA_RETAINED";
+        if (this.subjectStatusFilter === "deleted") return status === "DROPPED_DATA_DELETED";
+        return status !== "DROPPED_DATA_DELETED";
+      });
+    },
+    subjectCounts() {
+      const counts = { total: (this.subjects || []).length, active: 0, dropped: 0 };
+      (this.subjects || []).forEach((subject) => {
+        if (this.subjectStatus(subject) === "ACTIVE") counts.active += 1;
+        else if (this.subjectStatus(subject).startsWith("DROPPED_")) counts.dropped += 1;
+      });
+      return counts;
+    },
   },
 
   methods: {
+    subjectStatus(subject) {
+      return String(subject?.status || "ACTIVE").toUpperCase();
+    },
+    isDropped(subject) {
+      return this.subjectStatus(subject) !== "ACTIVE";
+    },
+    dropoutTitle(subject) {
+      const reason = subject?.dropout_reason || "Reason not available";
+      const date = subject?.dropout_date || "date not available";
+      return `Subject dropped out on ${date}: ${reason}. Data entry is disabled.`;
+    },
     onVisitChange(event) {
       const val = parseInt(event.target.value, 10);
       this.$emit("update:selectedVisitIndex", Number.isNaN(val) ? -1 : val);
@@ -286,15 +358,15 @@ export default {
         return;
       }
 
-      const subjects = Array.isArray(this.subjects) ? this.subjects : [];
+      const subjects = this.displayedSubjects;
 
       this.matchedSubjectIndices = subjects
-        .map((subject, index) => {
+        .map((item) => {
           const label = this.normalizeSearchText(
-            this.getSubjectSearchLabel(subject, index)
+            this.getSubjectSearchLabel(item.subject, item.sIdx)
           );
 
-          return label.includes(query) ? index : null;
+          return label.includes(query) ? item.sIdx : null;
         })
         .filter((index) => index !== null);
 
@@ -1053,6 +1125,31 @@ export default {
   transform: translateY(0);
 }
 
+.btn-dropout-subject {
+  border: 1px solid #be123c;
+  background: #fff1f2;
+  color: #9f1239;
+  border-radius: 7px;
+  padding: 9px 12px;
+  font-weight: 700;
+}
+
+.subject-status-filter {
+  display: grid;
+  gap: 3px;
+  color: #475569;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.subject-status-filter select { padding: 6px 8px; border: 1px solid #cbd5e1; border-radius: 6px; }
+.dropout-summary { padding: 7px 9px; border-radius: 999px; background: #f1f5f9; color: #334155; font-size: 12px; font-weight: 700; white-space: nowrap; }
+.subject-row-dropped { background: #fff1f2; color: #881337; }
+.subject-row-deleted { background: #f1f5f9; color: #64748b; }
+.subject-row-dropped .select-btn { cursor: not-allowed; filter: grayscale(.65); opacity: .6; }
+.dropout-badge { display: block; margin-top: 5px; color: #be123c; font-size: 12px; font-weight: 700; }
+.reactivate-btn { margin-top: 7px; padding: 4px 7px; border: 1px solid #047857; border-radius: 5px; color: #047857; background: #ecfdf5; font-size: 12px; }
+
 /* ========= Responsive ========= */
 @media (max-width: 900px) {
   .matrix-toolbar {
@@ -1092,6 +1189,7 @@ export default {
 
   .visit-select,
   .btn-add-subject,
+  .btn-dropout-subject,
   .version-helper {
     width: 100%;
   }

--- a/eCRF_frontend/src/components/SelectionMatrixView.vue
+++ b/eCRF_frontend/src/components/SelectionMatrixView.vue
@@ -160,12 +160,6 @@
                   <i class="fas fa-user-slash"></i>
                   {{ subjectStatus(item.subject) === 'DROPPED_DATA_DELETED' ? 'Data deleted' : 'Dropped out' }}
                 </span>
-                <button
-                  v-if="isAdmin && subjectStatus(item.subject) === 'DROPPED_DATA_RETAINED'"
-                  type="button"
-                  class="reactivate-btn"
-                  @click="$emit('reactivate-subject', item.sIdx)"
-                >Reactivate</button>
               </td>
 
 
@@ -184,15 +178,15 @@
               >
                 <button
                   class="select-btn"
-                  :class="statusClass(item.sIdx, vIdx)"
-                  :style="progressStyle(item.sIdx, vIdx)"
+                  :class="isDropped(item.subject) ? droppedStatusClass(item.subject) : statusClass(item.sIdx, vIdx)"
+                  :style="isDropped(item.subject) ? droppedProgressStyle : progressStyle(item.sIdx, vIdx)"
                   :disabled="isDropped(item.subject)"
                   :title="isDropped(item.subject) ? dropoutTitle(item.subject) : ''"
                   @click="$emit('select-cell', item.sIdx, vIdx)"
                 >
                   <span class="select-btn-fill"></span>
                   <span class="select-btn-label">
-                    {{ isDropped(item.subject) ? 'Dropped out' : (progressLabel(item.sIdx, vIdx) || "Select") }}
+                    {{ isDropped(item.subject) ? droppedCellLabel(item.subject) : (progressLabel(item.sIdx, vIdx) || "Select") }}
                   </span>
                 </button>
               </td>
@@ -243,13 +237,11 @@ export default {
 
     showGroupColumn: { type: Boolean, default: false },
     canManageSubjectDropout: { type: Boolean, default: false },
-    isAdmin: { type: Boolean, default: false },
   },
   emits: [
     "update:selectedVisitIndex",
     "add-subjects",
     "dropout-subject",
-    "reactivate-subject",
     "select-cell",
     "open-status-legend",
   ],
@@ -260,7 +252,7 @@ export default {
       matchedSubjectIndices: [],
       activeMatchPosition: 0,
       subjectRowRefs: {},
-      subjectStatusFilter: "active_and_retained",
+      subjectStatusFilter: "all",
     };
   },
 
@@ -287,6 +279,9 @@ export default {
       });
       return counts;
     },
+    droppedProgressStyle() {
+      return { "--progress-pct": "0%" };
+    },
   },
 
   methods: {
@@ -295,6 +290,16 @@ export default {
     },
     isDropped(subject) {
       return this.subjectStatus(subject) !== "ACTIVE";
+    },
+    droppedStatusClass(subject) {
+      return this.subjectStatus(subject) === "DROPPED_DATA_DELETED"
+        ? "status-dropped-deleted"
+        : "status-dropped-retained";
+    },
+    droppedCellLabel(subject) {
+      return this.subjectStatus(subject) === "DROPPED_DATA_DELETED"
+        ? "Dropped · Data deleted"
+        : "Dropped · Data retained";
     },
     dropoutTitle(subject) {
       const reason = subject?.dropout_reason || "Reason not available";
@@ -1060,6 +1065,26 @@ export default {
   border-color: #b91c1c;
 }
 
+.select-btn.status-dropped-retained {
+  background: #eef2ff;
+  border-color: #818cf8;
+  color: #4338ca;
+  box-shadow: none;
+}
+
+.select-btn.status-dropped-deleted {
+  background: #e2e8f0;
+  border-color: #64748b;
+  color: #334155;
+  box-shadow: none;
+}
+
+.select-btn.status-dropped-retained .select-btn-fill,
+.select-btn.status-dropped-deleted .select-btn-fill {
+  display: none;
+  width: 0;
+}
+
 /* ========= Scrollbars ========= */
 .matrix-wrap::-webkit-scrollbar {
   height: 10px;
@@ -1132,6 +1157,7 @@ export default {
   border-radius: 7px;
   padding: 9px 12px;
   font-weight: 700;
+  cursor: pointer;
 }
 
 .subject-status-filter {
@@ -1146,9 +1172,8 @@ export default {
 .dropout-summary { padding: 7px 9px; border-radius: 999px; background: #f1f5f9; color: #334155; font-size: 12px; font-weight: 700; white-space: nowrap; }
 .subject-row-dropped { background: #fff1f2; color: #881337; }
 .subject-row-deleted { background: #f1f5f9; color: #64748b; }
-.subject-row-dropped .select-btn { cursor: not-allowed; filter: grayscale(.65); opacity: .6; }
+.subject-row-dropped .select-btn { cursor: not-allowed; filter: none; opacity: 1; }
 .dropout-badge { display: block; margin-top: 5px; color: #be123c; font-size: 12px; font-weight: 700; }
-.reactivate-btn { margin-top: 7px; padding: 4px 7px; border: 1px solid #047857; border-radius: 5px; color: #047857; background: #ecfdf5; font-size: 12px; }
 
 /* ========= Responsive ========= */
 @media (max-width: 900px) {

--- a/eCRF_frontend/src/components/StudyAuditLogs.vue
+++ b/eCRF_frontend/src/components/StudyAuditLogs.vue
@@ -400,6 +400,10 @@ export default {
         share_link_created: "Share link created",
         access_changed: "Access changed",
         access_revoked: "Access revoked",
+        subject_dropped_keep_data: "Subject dropped out — data retained",
+        subject_dropped_delete_data: "Subject dropped out — data deleted",
+        subject_data_deletion_failed: "Subject data deletion failed",
+        subject_reactivated: "Subject reactivated",
       };
       return map[a] || row.action || "—";
     },
@@ -432,6 +436,14 @@ export default {
       if (a === "access_revoked") {
         return `Access revoked for ${d.target_user_display || d.target_user_email || `User#${d.target_user_id}`}`;
       }
+      if (a === "subject_dropped_keep_data") {
+        return `Subject dropped out; data retained (${d.dropout_reason || "reason unavailable"})`;
+      }
+      if (a === "subject_dropped_delete_data") {
+        return `Subject dropped out; ${d.entries_deleted || 0} record(s), ${d.files_deleted || 0} file(s) deleted`;
+      }
+      if (a === "subject_data_deletion_failed") return "Subject data deletion did not complete";
+      if (a === "subject_reactivated") return `Subject reactivated (${d.reactivation_reason || "reason unavailable"})`;
       return row.raw?.summary || "—";
     },
 

--- a/eCRF_frontend/src/components/StudyAuditLogs.vue
+++ b/eCRF_frontend/src/components/StudyAuditLogs.vue
@@ -403,7 +403,6 @@ export default {
         subject_dropped_keep_data: "Subject dropped out — data retained",
         subject_dropped_delete_data: "Subject dropped out — data deleted",
         subject_data_deletion_failed: "Subject data deletion failed",
-        subject_reactivated: "Subject reactivated",
       };
       return map[a] || row.action || "—";
     },
@@ -443,7 +442,6 @@ export default {
         return `Subject dropped out; ${d.entries_deleted || 0} record(s), ${d.files_deleted || 0} file(s) deleted`;
       }
       if (a === "subject_data_deletion_failed") return "Subject data deletion did not complete";
-      if (a === "subject_reactivated") return `Subject reactivated (${d.reactivation_reason || "reason unavailable"})`;
       return row.raw?.summary || "—";
     },
 

--- a/eCRF_frontend/src/components/StudyDataDashboard.vue
+++ b/eCRF_frontend/src/components/StudyDataDashboard.vue
@@ -137,22 +137,40 @@
 
           <tr class="filter-row">
               <th class="sticky-col sticky-subject">
-                <input v-model="filters.subjectId" placeholder="Filter Subject ID">
+                <select v-model="filters.subjectId" aria-label="Filter by subject">
+                  <option value="">All Subjects</option>
+                  <option v-for="subjectId in subjectFilterOptions" :key="`subject-${subjectId}`" :value="subjectId">
+                    {{ subjectId }}
+                  </option>
+                </select>
               </th>
 
               <th v-if="canViewGroupColumn" class="sticky-col sticky-group">
-                <input v-model="filters.group" placeholder="Filter Group">
+                <select v-model="filters.group" aria-label="Filter by group">
+                  <option value="">All Groups</option>
+                  <option v-for="group in groupFilterOptions" :key="`group-${group}`" :value="group">
+                    {{ group }}
+                  </option>
+                </select>
               </th>
 
               <th class="sticky-col sticky-visit">
-                <input v-model="filters.visit" placeholder="Filter Visit">
+                <select v-model="filters.visit" aria-label="Filter by visit">
+                  <option value="">All Visits</option>
+                  <option v-for="visit in visitFilterOptions" :key="`visit-${visit}`" :value="visit">
+                    {{ visit }}
+                  </option>
+                </select>
               </th>
 
             <template v-for="col in dashboardColumns" :key="'filter-'+col.key">
               <th>
                 <input
-                  v-model="filters[col.key]"
+                  :value="filterDrafts[col.key] || ''"
                   :placeholder="`Filter ${col.label}`"
+                  @input="onFieldFilterInput(col.key, $event.target.value)"
+                  @blur="applyFieldFilter(col.key)"
+                  @keydown.enter="applyFieldFilter(col.key)"
                 />
               </th>
             </template>
@@ -212,11 +230,26 @@
       </table>
 
       <div class="pagination-controls" v-if="!viewAll && !isLoadingEntries">
-        <button :disabled="currentPage === 1" @click="goFirst">First</button>
-        <button :disabled="currentPage === 1" @click="goPrev">Previous</button>
-        <span>Page {{ currentPage }} of {{ totalPages }}</span>
-        <button :disabled="currentPage === totalPages" @click="goNext">Next</button>
-        <button :disabled="currentPage === totalPages" @click="goLast">Last</button>
+        <span>Loaded first {{ loadedGridRows }} of {{ totalGridRows }} rows</span>
+        <button :disabled="currentPage === totalPages || isLoadingMore" @click="goNext">
+          {{ loadingMode === "next" ? "Loading…" : "Next" }}
+        </button>
+        <button
+          class="load-everything-button"
+          :disabled="currentPage === totalPages || isLoadingMore"
+          @click="loadEverything"
+        >
+          Load Everything
+        </button>
+        <span
+          v-if="loadingMode === 'all'"
+          class="load-everything-status"
+          role="status"
+          aria-live="polite"
+        >
+          <span class="pagination-spinner" aria-hidden="true"></span>
+          Loading all rows… This may take a while.
+        </span>
       </div>
     </div>
 
@@ -272,12 +305,16 @@ export default {
 
       sortConfig: { key: "subjectId", direction: "asc" },
       filters: { subjectId: "", group: "", visit: "" },
+      filterDrafts: {},
+      filterDebounceTimers: {},
 
       currentPage: 1,
       pageSize: 50,
       VIEW_ALL_MAX_ROWS: 1000,
       viewAll: false,
       isLoadingEntries: false,
+      isLoadingMore: false,
+      loadingMode: null,
 
       studyVersions: [],
       selectedVersion: null,
@@ -362,20 +399,41 @@ export default {
       return this.buildHeaderGroupsForColumns(this.dashboardColumns);
     },
 
-    filteredData() {
+    dashboardData() {
       return this.buildDashboardRows({
         entries: this.entries,
         columns: this.dashboardColumns,
         forceAllPairs: this.viewAll,
-        applyFilters: true,
-        applySort: true,
+        applyFilters: false,
+        applySort: false,
       });
+    },
+
+    subjectFilterOptions() {
+      return this.uniqueDashboardValues("subjectId");
+    },
+
+    groupFilterOptions() {
+      return this.uniqueDashboardValues("group");
+    },
+
+    visitFilterOptions() {
+      return this.uniqueDashboardValues("visit");
+    },
+
+    filteredData() {
+      const filtered = this.applyDashboardFilters(this.dashboardData, this.dashboardColumns);
+      return this.applyDashboardSort(filtered);
     },
 
     totalPages() {
       if (this.viewAll) return 1;
       const wholeGridPages = Math.ceil(Math.max(1, this.totalGridRows) / this.pageSize);
       return Math.max(1, wholeGridPages);
+    },
+
+    loadedGridRows() {
+      return Math.min(this.currentPage * this.pageSize, this.totalGridRows);
     },
 
     paginatedData() {
@@ -389,10 +447,6 @@ export default {
       this.currentPage = 1;
       this.fetchPageEntries();
     },
-    currentPage() {
-      if (this.viewAll) return;
-      this.fetchPageEntries();
-    },
     viewAll() {
       this.currentPage = 1;
       this.fetchPageEntries();
@@ -401,12 +455,6 @@ export default {
       this.$nextTick(() => {
         this.updateStickyColumnOffsets?.();
       });
-    },
-    filters: {
-      handler() {
-        if (!this.viewAll) this.fetchPageEntries();
-      },
-      deep: true,
     },
     selectedVersion: {
       async handler() {
@@ -436,6 +484,7 @@ export default {
 
   beforeUnmount() {
       window.removeEventListener("resize", this.updateStickyColumnOffsets);
+      Object.values(this.filterDebounceTimers).forEach((timer) => clearTimeout(timer));
     },
 
   methods: {
@@ -608,6 +657,11 @@ export default {
         next[col.key] = this.filters[col.key] || "";
       });
 
+      this.filterDrafts = this.dashboardColumns.reduce((drafts, col) => {
+        drafts[col.key] = this.filterDrafts[col.key] ?? next[col.key] ?? "";
+        return drafts;
+      }, {});
+
       if (!this.canViewGroupColumn) next.group = "";
 
       const currentKeys = Object.keys(this.filters).sort();
@@ -624,6 +678,31 @@ export default {
       if (sameValues) return;
 
       this.filters = next;
+    },
+
+    uniqueDashboardValues(key) {
+      return Array.from(
+        new Set(
+          this.dashboardData
+            .map((row) => String(row?.[key] ?? "").trim())
+            .filter(Boolean)
+        )
+      );
+    },
+
+    onFieldFilterInput(key, value) {
+      this.filterDrafts[key] = value;
+      clearTimeout(this.filterDebounceTimers[key]);
+      this.filterDebounceTimers[key] = setTimeout(() => {
+        this.filters[key] = value;
+        delete this.filterDebounceTimers[key];
+      }, 300);
+    },
+
+    applyFieldFilter(key) {
+      clearTimeout(this.filterDebounceTimers[key]);
+      delete this.filterDebounceTimers[key];
+      this.filters[key] = this.filterDrafts[key] || "";
     },
 
     async loadVersions(studyId) {
@@ -697,8 +776,9 @@ export default {
         };
       }
 
-      const pageStart = (this.currentPage - 1) * this.pageSize;
-      const pageEndExcl = Math.min(pageStart + this.pageSize, S * V);
+      const page = Number.isInteger(options.page) ? options.page : this.currentPage;
+      const pageStart = options.pageOnly === true ? (page - 1) * this.pageSize : 0;
+      const pageEndExcl = Math.min(page * this.pageSize, S * V);
 
       const subjSet = new Set();
       const visitSet = new Set();
@@ -725,22 +805,27 @@ export default {
       return windowInfo.pairKeySet.has(`${subjIdx}:${visitIdx}`);
     },
 
-    async fetchPageEntries() {
+    async fetchPageEntries(options = {}) {
       if (!this.study) return;
       const studyId = this.getStudyId();
+      const append = options.append === true;
+      const loadAll = options.loadAll === true;
 
-      const { subjectIdxPageSet, visitIdxPageSet } = this.currentWindowIndexSets();
+      const { subjectIdxPageSet, visitIdxPageSet } = this.currentWindowIndexSets({
+        ...options,
+        forceAll: loadAll,
+      });
 
-      const subject_indexes = this.viewAll
+      const subject_indexes = this.viewAll || loadAll
         ? null
         : Array.from(subjectIdxPageSet).sort((a, b) => a - b).join(",");
 
-      const visit_indexes = this.viewAll
+      const visit_indexes = this.viewAll || loadAll
         ? null
         : Array.from(visitIdxPageSet).sort((a, b) => a - b).join(",");
 
       const params = new URLSearchParams();
-      if (this.viewAll) params.append("all", "true");
+      if (this.viewAll || loadAll) params.append("all", "true");
       if (subject_indexes) params.append("subject_indexes", subject_indexes);
       if (visit_indexes) params.append("visit_indexes", visit_indexes);
       if (Number.isFinite(this.selectedVersion)) params.append("version", String(this.selectedVersion));
@@ -748,21 +833,53 @@ export default {
       const url = `/forms/studies/${studyId}/data_entries` + (params.toString() ? `?${params.toString()}` : "");
 
       try {
-        this.isLoadingEntries = true;
+        if (append) {
+          this.isLoadingMore = true;
+          this.loadingMode = loadAll ? "all" : "next";
+        }
+        else this.isLoadingEntries = true;
         const resp = await axios.get(url, {
           headers: { Authorization: `Bearer ${this.token}` },
         });
         const payload = Array.isArray(resp.data)
           ? { entries: resp.data, total: resp.data.length }
           : resp.data || {};
-        this.entries = payload.entries || [];
+        const incomingEntries = payload.entries || [];
+        this.entries = append
+          ? this.mergeDashboardEntries(this.entries, incomingEntries)
+          : incomingEntries;
         this.totalEntries = payload.total ?? this.entries.length;
+        return true;
       } catch (err) {
         console.error("Failed to load entries:", err);
-        this.entries = [];
+        if (!append) this.entries = [];
+        return false;
       } finally {
-        this.isLoadingEntries = false;
+        if (append) {
+          this.isLoadingMore = false;
+          this.loadingMode = null;
+        }
+        else this.isLoadingEntries = false;
       }
+    },
+
+    mergeDashboardEntries(existingEntries, incomingEntries) {
+      const merged = new Map();
+      const entryKey = (entry) => {
+        if (entry?.id != null) return `id:${entry.id}`;
+        return [
+          entry?.subject_index,
+          entry?.visit_index,
+          entry?.group_index,
+          entry?.form_version,
+        ].join(":");
+      };
+
+      [...(existingEntries || []), ...(incomingEntries || [])].forEach((entry) => {
+        merged.set(entryKey(entry), entry);
+      });
+
+      return Array.from(merged.values());
     },
 
     toggleExportMenu() {
@@ -1093,14 +1210,14 @@ export default {
 
     applyDashboardFilters(data, columns) {
       return data.filter((row) => {
-        if (this.filters.subjectId && !String(row.subjectId).toLowerCase().includes(this.filters.subjectId.toLowerCase())) return false;
-        if (this.canViewGroupColumn && this.filters.group && !String(row.group).toLowerCase().includes(this.filters.group.toLowerCase())) return false;
-        if (this.filters.visit && !String(row.visit).toLowerCase().includes(this.filters.visit.toLowerCase())) return false;
+        if (this.filters.subjectId && String(row.subjectId) !== String(this.filters.subjectId)) return false;
+        if (this.canViewGroupColumn && this.filters.group && String(row.group) !== String(this.filters.group)) return false;
+        if (this.filters.visit && String(row.visit) !== String(this.filters.visit)) return false;
 
         for (const col of columns) {
-          const filterVal = this.filters[col.key];
+          const filterVal = String(this.filters[col.key] ?? "").trim().toLowerCase();
           if (!filterVal) continue;
-          if (!String(row[col.key] ?? "").toLowerCase().includes(String(filterVal).toLowerCase())) {
+          if (!String(row[col.key] ?? "").toLowerCase().includes(filterVal)) {
             return false;
           }
         }
@@ -1321,17 +1438,24 @@ export default {
       }
     },
 
-    goFirst() {
-      this.currentPage = 1;
+    async goNext() {
+      if (this.currentPage >= this.totalPages || this.isLoadingMore) return;
+      const nextPage = this.currentPage + 1;
+      const loaded = await this.fetchPageEntries({
+        append: true,
+        page: nextPage,
+        pageOnly: true,
+      });
+      if (loaded) this.currentPage = nextPage;
     },
-    goPrev() {
-      if (this.currentPage > 1) this.currentPage--;
-    },
-    goNext() {
-      if (this.currentPage < this.totalPages) this.currentPage++;
-    },
-    goLast() {
-      this.currentPage = this.totalPages;
+    async loadEverything() {
+      if (this.currentPage >= this.totalPages || this.isLoadingMore) return;
+      const lastPage = this.totalPages;
+      const loaded = await this.fetchPageEntries({
+        append: true,
+        loadAll: true,
+      });
+      if (loaded) this.currentPage = lastPage;
     },
 
     async exportCSV() {
@@ -1895,7 +2019,8 @@ export default {
    FILTER ROW
    ============================================================ */
 
-.filter-row input {
+.filter-row input,
+.filter-row select {
   width: 100%;
   min-width: 120px;
   padding: 4px;
@@ -1964,6 +2089,35 @@ export default {
 .pagination-controls button:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+.pagination-controls .load-everything-button {
+  color: #1d4ed8;
+  background: #eff6ff;
+  border-color: #93c5fd;
+}
+
+.load-everything-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: #4b5563;
+}
+
+.pagination-spinner {
+  width: 16px;
+  height: 16px;
+  flex: 0 0 16px;
+  border: 2px solid #bfdbfe;
+  border-top-color: #2563eb;
+  border-radius: 50%;
+  animation: pagination-spin 0.8s linear infinite;
+}
+
+@keyframes pagination-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .pagination-controls span {

--- a/eCRF_frontend/src/components/StudyDataDashboard.vue
+++ b/eCRF_frontend/src/components/StudyDataDashboard.vue
@@ -192,7 +192,22 @@
         <tbody>
           <template v-for="(row, rowIdx) in paginatedData" :key="'row-'+rowIdx">
             <tr>
-              <td class="fixed-col sticky-col sticky-subject">{{ row.subjectId }}</td>
+              <td class="fixed-col sticky-col sticky-subject">
+                <span class="dashboard-subject-identity">
+                  <span>{{ row.subjectId }}</span>
+                  <span
+                    v-if="row.__subjectStatus !== 'ACTIVE'"
+                    class="dashboard-dropout-label"
+                    :class="{ 'dashboard-dropout-deleted': row.__subjectStatus === 'DROPPED_DATA_DELETED' }"
+                    :title="row.__subjectDropoutTitle"
+                  >
+                    <i class="fas fa-user-slash" aria-hidden="true"></i>
+                    {{ row.__subjectStatus === 'DROPPED_DATA_DELETED'
+                      ? 'Dropped out · Data deleted'
+                      : 'Dropped out · Data retained' }}
+                  </span>
+                </span>
+              </td>
               <td v-if="canViewGroupColumn" class="fixed-col sticky-col sticky-group">{{ row.group }}</td>
               <td class="fixed-col sticky-col sticky-visit">
                 <span class="visit-cell-content">
@@ -1251,6 +1266,10 @@ export default {
             subjectId: subject.id,
             group: groupName,
             visit: visit.name,
+            __subjectStatus: String(subject?.status || "ACTIVE").toUpperCase(),
+            __subjectDropoutTitle: subject?.status
+              ? `Dropped out${subject.dropout_date ? ` on ${subject.dropout_date}` : ""}${subject.dropout_reason ? `: ${subject.dropout_reason}${subject.dropout_reason === "Other" && subject.dropout_other_reason ? ` — ${subject.dropout_other_reason}` : ""}` : ""}`
+              : "",
             __sIdx: subjIdx,
             __vIdx: vIdx,
             __gIdx: groupIdx,
@@ -2136,6 +2155,28 @@ export default {
 
 .dashboard-table tbody td.cell-skipped.sticky-col {
   background: #fee2e2 !important;
+}
+
+.dashboard-subject-identity {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 5px;
+}
+
+.dashboard-dropout-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: #be123c;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
+.dashboard-dropout-deleted {
+  color: #991b1b;
 }
 
 /* ============================================================

--- a/eCRF_frontend/src/components/StudyDataDashboard.vue
+++ b/eCRF_frontend/src/components/StudyDataDashboard.vue
@@ -78,7 +78,19 @@
     </div>
 
     <div class="table-wrapper">
-      <div class="loading" v-if="isLoadingEntries">Building dashboard…</div>
+      <div
+        v-if="isBootstrapping || isLoadingEntries"
+        class="dashboard-loading-state"
+        role="status"
+        aria-live="polite"
+        aria-busy="true"
+      >
+        <div class="dashboard-loading-card">
+          <div class="dashboard-loading-spinner" aria-hidden="true"></div>
+          <div class="dashboard-loading-title">Please wait</div>
+          <div class="dashboard-loading-message">Study data is being loaded.</div>
+        </div>
+      </div>
 
       <table class="dashboard-table" v-else>
         <thead>
@@ -253,7 +265,7 @@
       </div>
     </div>
 
-    <div v-if="!filteredData.length && !isLoadingEntries" class="no-data">
+    <div v-if="!filteredData.length && !isBootstrapping && !isLoadingEntries" class="no-data">
       No data entries found. Please enter data for the assigned sections using the data entry form.
     </div>
 
@@ -267,8 +279,12 @@
     />
   </div>
 
-  <div v-else class="loading">
-    Loading study data…
+  <div v-else class="dashboard-loading-state dashboard-loading-standalone" role="status" aria-live="polite" aria-busy="true">
+    <div class="dashboard-loading-card">
+      <div class="dashboard-loading-spinner" aria-hidden="true"></div>
+      <div class="dashboard-loading-title">Please wait</div>
+      <div class="dashboard-loading-message">Study data is being loaded.</div>
+    </div>
   </div>
 </template>
 
@@ -290,7 +306,11 @@ export default {
   props: {
     studyId: { type: [String, Number], default: null },
     embedded: { type: Boolean, default: false },
+    active: { type: Boolean, default: true },
     fullscreen: { type: Boolean, default: false },
+    initialStudy: { type: Object, default: null },
+    initialVersions: { type: Array, default: null },
+    initialStudyFiles: { type: Array, default: null },
   },
   data() {
     return {
@@ -307,6 +327,7 @@ export default {
       filters: { subjectId: "", group: "", visit: "" },
       filterDrafts: {},
       filterDebounceTimers: {},
+      entryIndexCache: new WeakMap(),
 
       currentPage: 1,
       pageSize: 50,
@@ -315,6 +336,7 @@ export default {
       isLoadingEntries: false,
       isLoadingMore: false,
       loadingMode: null,
+      isBootstrapping: true,
 
       studyVersions: [],
       selectedVersion: null,
@@ -421,6 +443,21 @@ export default {
       return this.uniqueDashboardValues("visit");
     },
 
+    currentEntrySlotIndex() {
+      return this.buildEntrySlotIndex(this.entries);
+    },
+
+    studyFileSlotIndex() {
+      const index = new Map();
+      (this.studyFiles || []).forEach((file) => {
+        const key = this.studyFileSlotKey(file?.subject_index, file?.visit_index);
+        const files = index.get(key);
+        if (files) files.push(file);
+        else index.set(key, [file]);
+      });
+      return index;
+    },
+
     filteredData() {
       const filtered = this.applyDashboardFilters(this.dashboardData, this.dashboardColumns);
       return this.applyDashboardSort(filtered);
@@ -442,6 +479,14 @@ export default {
   },
 
   watch: {
+    initialStudyFiles(nextFiles) {
+      if (Array.isArray(nextFiles)) this.studyFiles = nextFiles;
+    },
+    initialVersions(nextVersions) {
+      if (Array.isArray(nextVersions)) {
+        this.studyVersions = [...nextVersions].sort((a, b) => a.version - b.version);
+      }
+    },
     pageSize() {
       if (this.viewAll) return;
       this.currentPage = 1;
@@ -456,9 +501,15 @@ export default {
         this.updateStickyColumnOffsets?.();
       });
     },
+    active(isActive) {
+      if (!isActive) return;
+      this.$nextTick(() => {
+        this.updateStickyColumnOffsets?.();
+      });
+    },
     selectedVersion: {
       async handler() {
-        if (!this.study) return;
+        if (!this.study || this.isBootstrapping) return;
         await this.loadTemplateForSelectedVersion();
         this.initDynamicFilters();
         this.currentPage = 1;
@@ -601,17 +652,29 @@ export default {
     async bootstrap() {
       const studyId = this.getStudyId();
       try {
-        const studyResp = await axios.get(`/forms/studies/${studyId}`, {
-          headers: { Authorization: `Bearer ${this.token}` },
-        });
-        this.study = studyResp.data;
+        if (this.initialStudy) {
+          this.study = this.cloneStudyPayload(this.initialStudy);
+        } else {
+          const studyResp = await axios.get(`/forms/studies/${studyId}`, {
+            headers: { Authorization: `Bearer ${this.token}` },
+          });
+          this.study = studyResp.data;
+        }
 
-        await this.loadVersions(studyId);
+        if (Array.isArray(this.initialVersions)) {
+          this.studyVersions = [...this.initialVersions].sort((a, b) => a.version - b.version);
+        } else {
+          await this.loadVersions(studyId);
+        }
         if (!this.selectedVersion && this.studyVersions.length) {
           this.selectedVersion = this.studyVersions[this.studyVersions.length - 1].version;
         }
         await this.loadTemplateForSelectedVersion();
-        await this.loadStudyFiles(studyId);
+        if (Array.isArray(this.initialStudyFiles)) {
+          this.studyFiles = this.initialStudyFiles;
+        } else {
+          await this.loadStudyFiles(studyId);
+        }
 
         this.initDynamicFilters();
 
@@ -624,7 +687,20 @@ export default {
         } else {
           alert("Could not load study data");
         }
+      } finally {
+        this.isBootstrapping = false;
       }
+    },
+
+    cloneStudyPayload(payload) {
+      if (typeof structuredClone === "function") {
+        try {
+          return structuredClone(payload);
+        } catch {
+          // Vue props may be reactive proxies, which structuredClone cannot clone.
+        }
+      }
+      return JSON.parse(JSON.stringify(payload));
     },
 
     async loadStudyFiles(studyId) {
@@ -910,24 +986,66 @@ export default {
     },
 
     findBestEntryFromEntries(entries, subjIdx, visitIdx, groupIdx) {
-      const all = (entries || []).filter(
-        (e) =>
-          e.subject_index === subjIdx &&
-          e.visit_index === visitIdx &&
-          e.group_index === groupIdx
-      );
+      const index = this.entrySlotIndexFor(entries);
+      const all = index.get(this.entrySlotKey(subjIdx, visitIdx, groupIdx)) || [];
       if (!all.length) return null;
 
       const target = Number(this.selectedVersion);
       const exact = all.find((e) => Number(e.form_version) === target);
       if (exact) return exact;
 
-      const le = all
-        .filter((e) => Number(e.form_version) <= target)
-        .sort((a, b) => Number(b.form_version) - Number(a.form_version))[0];
-      if (le) return le;
+      let bestAtOrBefore = null;
+      let bestAtOrBeforeVersion = -Infinity;
+      let latest = all[0];
+      let latestVersion = Number(latest?.form_version);
 
-      return all.sort((a, b) => Number(b.form_version) - Number(a.form_version))[0];
+      all.forEach((entry) => {
+        const version = Number(entry?.form_version);
+        if (version <= target && version > bestAtOrBeforeVersion) {
+          bestAtOrBefore = entry;
+          bestAtOrBeforeVersion = version;
+        }
+        if (version > latestVersion) {
+          latest = entry;
+          latestVersion = version;
+        }
+      });
+
+      if (bestAtOrBefore) return bestAtOrBefore;
+
+      return latest;
+    },
+
+    entrySlotKey(subjIdx, visitIdx, groupIdx) {
+      const typed = (value) => `${typeof value}:${String(value)}`;
+      return `${typed(subjIdx)}|${typed(visitIdx)}|${typed(groupIdx)}`;
+    },
+
+    buildEntrySlotIndex(entries) {
+      const index = new Map();
+      (entries || []).forEach((entry) => {
+        const key = this.entrySlotKey(
+          entry?.subject_index,
+          entry?.visit_index,
+          entry?.group_index
+        );
+        const slotEntries = index.get(key);
+        if (slotEntries) slotEntries.push(entry);
+        else index.set(key, [entry]);
+      });
+      return index;
+    },
+
+    entrySlotIndexFor(entries) {
+      if (entries === this.entries) return this.currentEntrySlotIndex;
+      if (!entries || typeof entries !== "object") return new Map();
+
+      const cached = this.entryIndexCache.get(entries);
+      if (cached) return cached;
+
+      const index = this.buildEntrySlotIndex(entries);
+      this.entryIndexCache.set(entries, index);
+      return index;
     },
 
     getValue(subjIdx, visitIdx, sectionIdx, fieldIdx) {
@@ -937,6 +1055,10 @@ export default {
     getValueFromEntries(entries, subjIdx, visitIdx, sectionIdx, fieldIdx) {
       const groupIdx = this.resolveGroup(subjIdx);
       const entry = this.findBestEntryFromEntries(entries, subjIdx, visitIdx, groupIdx);
+      return this.getValueFromEntry(entry, sectionIdx, fieldIdx);
+    },
+
+    getValueFromEntry(entry, sectionIdx, fieldIdx) {
       if (!entry || !entry.data) return "";
 
       const d = entry.data;
@@ -954,7 +1076,13 @@ export default {
     },
 
     getTableRowsFromEntries(entries, subjIdx, visitIdx, sectionIdx, fieldIdx) {
-      const raw = this.getValueFromEntries(entries, subjIdx, visitIdx, sectionIdx, fieldIdx);
+      const groupIdx = this.resolveGroup(subjIdx);
+      const entry = this.findBestEntryFromEntries(entries, subjIdx, visitIdx, groupIdx);
+      return this.getTableRowsFromEntry(entry, sectionIdx, fieldIdx);
+    },
+
+    getTableRowsFromEntry(entry, sectionIdx, fieldIdx) {
+      const raw = this.getValueFromEntry(entry, sectionIdx, fieldIdx);
       if (!raw || typeof raw !== "object") return [];
       if (!Array.isArray(raw.rows)) return [];
       return raw.rows;
@@ -1131,6 +1259,7 @@ export default {
           };
 
           const entry = this.findBestEntryFromEntries(entries, subjIdx, vIdx, groupIdx);
+          row.__skippedRequiredFlags = entry?.skipped_required_flags || null;
           row.__uploadedFiles = this.uploadedFilesForRow(subjIdx, vIdx, entry?.data || []);
 
           columns.forEach((col) => {
@@ -1143,7 +1272,7 @@ export default {
 
             if (col.kind === "normal") {
               const field = this.sections?.[col.sIdx]?.fields?.[col.fIdx];
-              const raw = this.getValueFromEntries(entries, subjIdx, vIdx, col.sIdx, col.fIdx);
+              const raw = this.getValueFromEntry(entry, col.sIdx, col.fIdx);
               const type = String(field?.type || "").toLowerCase();
 
               if (type === "checkbox") {
@@ -1167,12 +1296,12 @@ export default {
             }
 
             if (col.kind === "tableCell") {
-                const field = this.sections?.[col.sIdx]?.fields?.[col.fIdx];
-                const tableRows = this.getTableRowsFromEntries(entries, subjIdx, vIdx, col.sIdx, col.fIdx);
-                const tableRow = tableRows[col.tableRowIdx] || null;
-                const tableColDef = field?.tableConfig?.columns?.[col.tIdx] || {};
-                const raw = this.readTableCellValue(tableRow, tableColDef, col.tIdx);
-                const tableColType = String(tableColDef?.type || "").toLowerCase();
+              const field = this.sections?.[col.sIdx]?.fields?.[col.fIdx];
+              const tableRows = this.getTableRowsFromEntry(entry, col.sIdx, col.fIdx);
+              const tableRow = tableRows[col.tableRowIdx] || null;
+              const tableColDef = field?.tableConfig?.columns?.[col.tIdx] || {};
+              const raw = this.readTableCellValue(tableRow, tableColDef, col.tIdx);
+              const tableColType = String(tableColDef?.type || "").toLowerCase();
 
               if (tableColType === "checkbox") {
                 row[col.key] = raw === true ? "Yes" : raw === false ? "No" : "";
@@ -1260,24 +1389,18 @@ export default {
       });
     },
 
-    isCellSkipped(subjIdx, visitIdx, sectionIdx, fieldIdx) {
-      const groupIdx = this.resolveGroup(subjIdx);
-      const entry = this.findBestEntry(subjIdx, visitIdx, groupIdx);
-      if (!entry) return false;
-      const flags = entry.skipped_required_flags;
-      return !!(
-        Array.isArray(flags) &&
-        Array.isArray(flags[sectionIdx]) &&
-        flags[sectionIdx][fieldIdx] === true
-      );
-    },
-
     dashboardCellClass(row, col) {
       if (col.kind === "normal") {
         const assigned = this.isAssigned(col.sIdx, row.__vIdx, row.__gIdx);
+        const skippedFlags = row.__skippedRequiredFlags;
+        const skipped = !!(
+          Array.isArray(skippedFlags) &&
+          Array.isArray(skippedFlags[col.sIdx]) &&
+          skippedFlags[col.sIdx][col.fIdx] === true
+        );
         return {
           "cell-unassigned": !assigned,
-          "cell-skipped": assigned && this.isCellSkipped(row.__sIdx, row.__vIdx, col.sIdx, col.fIdx),
+          "cell-skipped": assigned && skipped,
         };
       }
 
@@ -1333,11 +1456,11 @@ export default {
     },
 
     studyFileRecordsForCell(sIdx, vIdx) {
-      return (this.studyFiles || []).filter(
-        (file) =>
-          Number(file?.subject_index) === Number(sIdx) &&
-          Number(file?.visit_index) === Number(vIdx)
-      );
+      return this.studyFileSlotIndex.get(this.studyFileSlotKey(sIdx, vIdx)) || [];
+    },
+
+    studyFileSlotKey(sIdx, vIdx) {
+      return `${Number(sIdx)}:${Number(vIdx)}`;
     },
 
     uploadedFilesForRow(sIdx, vIdx, data) {
@@ -2038,6 +2161,58 @@ export default {
   text-align: center;
   padding: 24px;
   color: #6b7280;
+}
+
+.dashboard-loading-state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  min-height: 240px;
+  padding: 24px;
+  box-sizing: border-box;
+}
+
+.dashboard-loading-standalone {
+  min-height: 100vh;
+}
+
+.dashboard-loading-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  min-width: 260px;
+  padding: 24px 28px;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  background: #fff;
+  box-shadow: 0 18px 45px rgba(15, 23, 42, 0.14);
+  color: #111827;
+  text-align: center;
+}
+
+.dashboard-loading-spinner {
+  width: 34px;
+  height: 34px;
+  border: 4px solid #e5e7eb;
+  border-top-color: #2563eb;
+  border-radius: 50%;
+  animation: dashboard-loading-spin 0.8s linear infinite;
+}
+
+.dashboard-loading-title {
+  font-size: 16px;
+  font-weight: 700;
+}
+
+.dashboard-loading-message {
+  font-size: 14px;
+  color: #4b5563;
+}
+
+@keyframes dashboard-loading-spin {
+  to { transform: rotate(360deg); }
 }
 
 .no-data {

--- a/eCRF_frontend/src/components/StudyDataEntryComponent.vue
+++ b/eCRF_frontend/src/components/StudyDataEntryComponent.vue
@@ -107,8 +107,12 @@
           :selectedVersion="selectedVersion"
           :infoIcon="icons.info"
           :showGroupColumn="canSeeGroupColumn"
+          :canManageSubjectDropout="canManageSubjectDropout"
+          :isAdmin="isAdminUser"
           @update:selectedVisitIndex="selectedVisitIndex = $event"
           @add-subjects="openSubjectDialog"
+          @dropout-subject="openSubjectDropoutDialog"
+          @reactivate-subject="reactivateSubject"
           @select-cell="selectCell"
           @open-status-legend="openStatusLegend"
         />
@@ -699,6 +703,17 @@
       @save="saveNewSubjects"
     />
 
+    <SubjectDropoutDialog
+      v-if="showSubjectDropoutDialog"
+      :subjects="sd.subjects"
+      :entries="existingEntries"
+      :files="studyFiles"
+      :saving="savingSubjectDropout"
+      :error="subjectDropoutError"
+      @close="closeSubjectDropoutDialog"
+      @submit="submitSubjectDropout"
+    />
+
     <GroupAssignDialog
       :visible="showGroupAssignDialog"
       :groupAssignScope="groupAssignScope"
@@ -846,6 +861,7 @@ import FieldLinearScale from "@/components/fields/FieldLinearScale.vue";
 import FieldFileUpload from "@/components/fields/FieldFileUpload.vue";
 import SelectionMatrixView from "@/components/SelectionMatrixView.vue";
 import AddSubjectsDialog from "@/components/AddSubjectsDialog.vue";
+import SubjectDropoutDialog from "@/components/SubjectDropoutDialog.vue";
 import { createAjv, validateFieldValue } from "@/utils/jsonschemaValidation";
 
 import MergeStudy from "@/components/MergeStudy.vue";
@@ -917,6 +933,7 @@ export default {
     FieldFileUpload,
     SelectionMatrixView,
     AddSubjectsDialog,
+    SubjectDropoutDialog,
     MergeStudy,
     StudyShareDialog,
     PermissionDeniedDialog,
@@ -1018,6 +1035,9 @@ export default {
       subjectDrafts: [],
       subjectDialogError: "",
       savingSubjects: false,
+      showSubjectDropoutDialog: false,
+      savingSubjectDropout: false,
+      subjectDropoutError: "",
 
       // Merge mode (selection panel toggles to merge UI in same container)
       isMergeMode: false,
@@ -1107,8 +1127,9 @@ export default {
           index,
           id: String(subject?.id || subject?.subject_id || `Subject ${index + 1}`).trim(),
           group: String(subject?.group || "").trim() || "Unassigned",
+          status: String(subject?.status || "ACTIVE").toUpperCase(),
         }))
-        .filter((subject) => subject.group === currentGroup);
+        .filter((subject) => subject.group === currentGroup && subject.status === "ACTIVE");
     },
 
     shareDialogSectionAvailabilityByVisit() {
@@ -1164,8 +1185,9 @@ export default {
           index: idx,
           label: subjectLabel,
           groupLabel: groupName || "Unassigned",
+          status: String(s?.status || "ACTIVE").toUpperCase(),
         };
-      });
+      }).filter((subject) => subject.status === "ACTIVE");
     },
     importableFields() {
       const models = Array.isArray(this.selectedModels) ? this.selectedModels : [];
@@ -1249,6 +1271,7 @@ export default {
       const subjects = this.sd.subjects || [];
       const out = [];
       for (let i = 0; i < subjects.length; i++) {
+        if (String(subjects[i]?.status || "ACTIVE").toUpperCase() !== "ACTIVE") continue;
         const g = String(subjects[i]?.group || "").trim();
         if (!g) out.push(i);
       }
@@ -1259,9 +1282,17 @@ export default {
 
       const isCreator = this.study.metadata.created_by === this.$store.state.user?.id;
       const hasAddPermission = this.isShared && this.sharedPermission === "add";
-      const isAdmin = this.$store.state.user?.role === "Administrator";
+      const isAdmin = this.isAdminUser;
 
       return isCreator || hasAddPermission || isAdmin;
+    },
+    isAdminUser() {
+      const user = this.$store.getters.getUser || this.$store.state.user || {};
+      return (user.profile?.role || user.role || "") === "Administrator";
+    },
+    canManageSubjectDropout() {
+      if (this.isShared || !this.study?.metadata) return false;
+      return this.isAdminUser || Number(this.study.metadata.created_by) === Number(this.$store.state.user?.id);
     },
     studyId() {
       const id = Number(this.$route.params.id);
@@ -5976,6 +6007,13 @@ applyImportedRowFromDialog(payload) {
       }
     },
     async selectCell(sIdx, vIdx) {
+      const selectedSubject = this.sd.subjects?.[sIdx];
+      if (String(selectedSubject?.status || "ACTIVE").toUpperCase() !== "ACTIVE") {
+        this.showDialogMessage(
+          `Subject ${selectedSubject?.id || sIdx + 1} has been dropped out. Data entry is disabled.`
+        );
+        return;
+      }
       const nS = this.numberOfSubjects;
       const nV = this.visitList.length;
 
@@ -7201,6 +7239,70 @@ applyImportedRowFromDialog(payload) {
 
       this.generateSubjectDrafts();
       this.showSubjectDialog = true;
+    },
+
+    openSubjectDropoutDialog() {
+      if (!this.canManageSubjectDropout) {
+        this.showDialogMessage("Only an administrator or the study author can drop out a subject.");
+        return;
+      }
+      this.subjectDropoutError = "";
+      this.showSubjectDropoutDialog = true;
+    },
+
+    closeSubjectDropoutDialog() {
+      if (this.savingSubjectDropout) return;
+      this.showSubjectDropoutDialog = false;
+      this.subjectDropoutError = "";
+    },
+
+    async submitSubjectDropout(request) {
+      if (!this.canManageSubjectDropout || this.savingSubjectDropout) return;
+      this.savingSubjectDropout = true;
+      this.subjectDropoutError = "";
+      try {
+        const { subjectIndex, ...payload } = request;
+        const response = await axios.post(
+          `/forms/studies/${this.study.metadata.id}/subjects/${subjectIndex}/dropout`,
+          payload,
+          { headers: { Authorization: `Bearer ${this.token}` } }
+        );
+        this.showSubjectDropoutDialog = false;
+        await this.loadStudy(this.study.metadata.id);
+        await this.loadExistingEntries(this.study.metadata.id);
+        await this.loadStudyFiles(this.study.metadata.id);
+        this.buildStatusCache();
+        this.showDialogMessage(
+          response.data?.status === "DROPPED_DATA_DELETED"
+            ? `Subject ${response.data.subject_id} was dropped out and active application data was deleted.`
+            : `Subject ${response.data.subject_id} was dropped out. Existing data is now read-only.`
+        );
+      } catch (error) {
+        this.subjectDropoutError = this.getApiErrorDetail(error) || "Failed to drop out subject.";
+      } finally {
+        this.savingSubjectDropout = false;
+      }
+    },
+
+    async reactivateSubject(subjectIndex) {
+      if (!this.isAdminUser) return;
+      const subject = this.sd.subjects?.[subjectIndex];
+      if (!subject) return;
+      const reason = window.prompt(`Reason for reactivating subject ${subject.id}:`);
+      if (!reason || !reason.trim()) return;
+      try {
+        await axios.post(
+          `/forms/studies/${this.study.metadata.id}/subjects/${subjectIndex}/reactivate`,
+          { reason: reason.trim() },
+          { headers: { Authorization: `Bearer ${this.token}` } }
+        );
+        await this.loadStudy(this.study.metadata.id);
+        await this.loadExistingEntries(this.study.metadata.id);
+        this.buildStatusCache();
+        this.showDialogMessage(`Subject ${subject.id} was reactivated.`);
+      } catch (error) {
+        this.showDialogMessage(this.getApiErrorDetail(error) || "Failed to reactivate subject.");
+      }
     },
 
     closeSubjectDialog() {

--- a/eCRF_frontend/src/components/StudyDataEntryComponent.vue
+++ b/eCRF_frontend/src/components/StudyDataEntryComponent.vue
@@ -108,11 +108,9 @@
           :infoIcon="icons.info"
           :showGroupColumn="canSeeGroupColumn"
           :canManageSubjectDropout="canManageSubjectDropout"
-          :isAdmin="isAdminUser"
           @update:selectedVisitIndex="selectedVisitIndex = $event"
           @add-subjects="openSubjectDialog"
           @dropout-subject="openSubjectDropoutDialog"
-          @reactivate-subject="reactivateSubject"
           @select-cell="selectCell"
           @open-status-legend="openStatusLegend"
         />
@@ -7281,27 +7279,6 @@ applyImportedRowFromDialog(payload) {
         this.subjectDropoutError = this.getApiErrorDetail(error) || "Failed to drop out subject.";
       } finally {
         this.savingSubjectDropout = false;
-      }
-    },
-
-    async reactivateSubject(subjectIndex) {
-      if (!this.isAdminUser) return;
-      const subject = this.sd.subjects?.[subjectIndex];
-      if (!subject) return;
-      const reason = window.prompt(`Reason for reactivating subject ${subject.id}:`);
-      if (!reason || !reason.trim()) return;
-      try {
-        await axios.post(
-          `/forms/studies/${this.study.metadata.id}/subjects/${subjectIndex}/reactivate`,
-          { reason: reason.trim() },
-          { headers: { Authorization: `Bearer ${this.token}` } }
-        );
-        await this.loadStudy(this.study.metadata.id);
-        await this.loadExistingEntries(this.study.metadata.id);
-        this.buildStatusCache();
-        this.showDialogMessage(`Subject ${subject.id} was reactivated.`);
-      } catch (error) {
-        this.showDialogMessage(this.getApiErrorDetail(error) || "Failed to reactivate subject.");
       }
     },
 

--- a/eCRF_frontend/src/components/StudyView.vue
+++ b/eCRF_frontend/src/components/StudyView.vue
@@ -571,16 +571,6 @@
           </div>
         </div>
 
-        <!-- VIEW DATA: embedded (NO routing) -->
-        <div v-else-if="activeTab === 'viewdata'" class="viewdata-host">
-          <StudyDataDashboard
-            :study-id="studyId"
-            :embedded="true"
-            :fullscreen="dashboardFullscreen"
-            @toggle-fullscreen="toggleDashboardFullscreen"
-          />
-        </div>
-
         <!-- AUDIT LOGS -->
         <div v-else-if="activeTab === 'audit'">
           <StudyAuditLogs :study-id="studyId" />
@@ -669,6 +659,22 @@
             </p>
           </template>
         </div>
+
+        <!-- Keep View Data mounted after its first visit so switching tabs does not rebuild it. -->
+        <div v-show="activeTab === 'viewdata'" class="viewdata-host">
+          <StudyDataDashboard
+            v-if="viewDataInitialized && sharedStudyDataReady"
+            :key="`viewdata-${studyId}`"
+            :study-id="studyId"
+            :embedded="true"
+            :active="activeTab === 'viewdata'"
+            :fullscreen="dashboardFullscreen"
+            :initial-study="studyRecord"
+            :initial-versions="versions"
+            :initial-study-files="allFiles"
+            @toggle-fullscreen="toggleDashboardFullscreen"
+          />
+        </div>
       </section>
     </div>
     <!-- Delete study confirm dialog -->
@@ -724,6 +730,8 @@ export default {
       studyLoading: true,
       maintenanceMessage: "",
       studyId: this.$route.params.id,
+      studyRecord: null,
+      sharedStudyDataReady: false,
 
       // meta/content
       studyMeta: {
@@ -755,6 +763,7 @@ export default {
       // View Data embedding state
       dataSidebarCollapsed: false,
       dashboardFullscreen: false,
+      viewDataInitialized: false,
 
       // tabs
       activeTab: "meta",
@@ -804,6 +813,7 @@ export default {
       versionSchemas: {},
       versionDiffs: {},
       canShowVersionDetails: true,
+      versionDetailsLoaded: false,
 
       bidsDatasetPath: "",
       bidsPathExists: false,
@@ -909,6 +919,7 @@ export default {
 
       if (val === "viewdata") {
         this.dataSidebarCollapsed = true;
+        this.viewDataInitialized = true;
       } else {
         this.dataSidebarCollapsed = false;
         this.dashboardFullscreen = false;
@@ -974,7 +985,11 @@ export default {
 
     toggleMetaSection(key) {
       if (!key || !Object.prototype.hasOwnProperty.call(this.metaCollapsed, key)) return;
+      const isOpening = this.metaCollapsed[key] === true;
       this.metaCollapsed[key] = !this.metaCollapsed[key];
+      if (key === "versions" && isOpening && !this.versionDetailsLoaded) {
+        this.fetchVersionDiffDetails();
+      }
     },
 
     // ExportStudy shown in SAME container; no back button + no extra header
@@ -1219,6 +1234,7 @@ export default {
       try {
         this.maintenanceMessage = "";
         const resp = await axios.get(`/forms/studies/${this.studyId}`, { headers: { Authorization: `Bearer ${token}` } });
+        this.studyRecord = resp.data || null;
         const sd = resp.data?.content?.study_data || {};
         const meta = resp.data?.metadata || {};
 
@@ -1290,15 +1306,36 @@ export default {
     async fetchVersionsAndDiffs() {
       const token = this.token;
       if (!token) return;
+      let shouldLoadVisibleDetails = false;
       this.versionsLoading = true;
       this.canShowVersionDetails = true;
       try {
         const { data } = await axios.get(`/forms/studies/${this.studyId}/versions`, { headers: { Authorization: `Bearer ${token}` } });
         const list = Array.isArray(data) ? data : [];
         this.versions = [...list].sort((a, b) => Number(a.version) - Number(b.version));
+        this.versionSchemas = {};
+        this.versionDiffs = {};
+        this.versionDetailsLoaded = this.versions.length === 0;
+        shouldLoadVisibleDetails = !this.metaCollapsed.versions && this.versions.length > 0;
+      } catch (e) {
+        console.error("fetchVersionsAndDiffs failed:", e?.response?.data || e.message);
+        this.versions = [];
+        this.versionSchemas = {};
+        this.versionDiffs = {};
+        this.versionDetailsLoaded = false;
+      } finally {
+        this.versionsLoading = false;
+      }
+      if (shouldLoadVisibleDetails) await this.fetchVersionDiffDetails();
+    },
 
-        if (!this.versions.length) { this.versionSchemas = {}; this.versionDiffs = {}; return; }
+    async fetchVersionDiffDetails() {
+      const token = this.token;
+      if (!token || this.versionDetailsLoaded || this.versionsLoading || !this.versions.length) return;
 
+      this.versionsLoading = true;
+      this.canShowVersionDetails = true;
+      try {
         const schemas = {};
         for (const v of this.versions) {
           try {
@@ -1308,29 +1345,33 @@ export default {
             schemas[v.version] = resp.data?.schema || {};
           } catch (e) {
             if (e?.response?.status === 403) { this.canShowVersionDetails = false; break; }
-            console.warn(`Failed to fetch schema for v${v.version}:`, e?.response?.data || e.message);
+            throw e;
           }
         }
         this.versionSchemas = schemas;
 
-        if (!this.canShowVersionDetails) { this.versionDiffs = {}; return; }
+        if (!this.canShowVersionDetails) {
+          this.versionDiffs = {};
+          this.versionDetailsLoaded = true;
+          return;
+        }
 
         const diffs = {};
         for (const v of this.versions) {
           const ver = Number(v.version);
           if (ver <= 1) continue;
-          const prev = this.versionSchemas[ver - 1];
-          const next = this.versionSchemas[ver];
-          if (prev && next) {
-            const d = computeTemplateDiff(prev, next);
-            d.summary = buildVersionSummary(d);
-            diffs[ver] = d;
+          const previousSchema = schemas[ver - 1];
+          const nextSchema = schemas[ver];
+          if (previousSchema && nextSchema) {
+            const diff = computeTemplateDiff(previousSchema, nextSchema);
+            diff.summary = buildVersionSummary(diff);
+            diffs[ver] = diff;
           }
         }
         this.versionDiffs = diffs;
+        this.versionDetailsLoaded = true;
       } catch (e) {
-        console.error("fetchVersionsAndDiffs failed:", e?.response?.data || e.message);
-        this.versions = [];
+        console.error("fetchVersionDiffDetails failed:", e?.response?.data || e.message);
         this.versionSchemas = {};
         this.versionDiffs = {};
       } finally {
@@ -1660,6 +1701,7 @@ export default {
   },
   async mounted() {
     this.studyLoading = true;
+    this.sharedStudyDataReady = false;
     try {
       this.scrollToTop?.();
 
@@ -1675,18 +1717,30 @@ export default {
 
       if (this.canSeeBidsButton) await this.fetchBidsPath();
       await Promise.all([this.fetchStudyFiles(), this.fetchVersionsAndDiffs()]);
+      this.sharedStudyDataReady = true;
     } finally {
       this.studyLoading = false;
     }
   },
   beforeRouteEnter(to, from, next) { next((vm) => vm.scrollToTop?.()); },
   beforeRouteUpdate(to, from, next) {
+    if (String(to.params.id) === String(from.params.id)) {
+      const qTab = to.query?.tab;
+      if (qTab && this.tabs.some(t => t.key === qTab) && qTab !== this.activeTab) {
+        this.activeTab = qTab;
+      }
+      next();
+      return;
+    }
+
     this.studyLoading = true;
+    this.sharedStudyDataReady = false;
     this.maintenanceMessage = "";
     this.studyId = to.params.id;
 
     const qTab = to.query?.tab;
     if (qTab && this.tabs.some(t => t.key === qTab)) this.activeTab = qTab;
+    this.viewDataInitialized = this.activeTab === "viewdata";
 
     this.scrollToTop?.();
     Promise.resolve()
@@ -1705,6 +1759,7 @@ export default {
         return Promise.all([this.fetchStudyFiles(), this.fetchVersionsAndDiffs()]);
       })
       .finally(() => {
+        this.sharedStudyDataReady = !this.maintenanceMessage;
         this.studyLoading = false;
         next();
       });

--- a/eCRF_frontend/src/components/SubjectDropoutDialog.vue
+++ b/eCRF_frontend/src/components/SubjectDropoutDialog.vue
@@ -1,0 +1,177 @@
+<template>
+  <div class="dropout-backdrop" role="presentation" @click.self="$emit('close')">
+    <section class="dropout-dialog" role="dialog" aria-modal="true" aria-labelledby="dropout-title">
+      <h3 id="dropout-title">Drop out subject</h3>
+
+      <template v-if="!mode">
+        <p>How do you want to drop out this subject?</p>
+        <button class="choice" type="button" @click="mode = 'keep_data'">
+          <strong>Drop out and keep existing data</strong>
+          <span>Existing data remains read-only. No new data can be added.</span>
+        </button>
+        <button class="choice danger-choice" type="button" @click="mode = 'delete_data'">
+          <strong>Drop out and delete subject data</strong>
+          <span>Removes data and file references from the active Case-e dataset.</span>
+        </button>
+      </template>
+
+      <form v-else @submit.prevent="submit">
+        <label>
+          Subject ID
+          <select v-model.number="subjectIndex" required>
+            <option :value="null" disabled>Select a subject</option>
+            <option v-for="item in activeSubjects" :key="item.index" :value="item.index">
+              {{ item.id }} · {{ item.group || 'Unassigned' }}
+            </option>
+          </select>
+        </label>
+
+        <div v-if="selectedSubject" class="subject-facts">
+          <strong>{{ selectedSubject.id }}</strong>
+          <span>{{ entryCount }} data record(s) · {{ fileCount }} uploaded file/reference(s)</span>
+        </div>
+
+        <label>
+          Dropout date
+          <input v-model="dropoutDate" type="date" required />
+        </label>
+
+        <label>
+          Dropout reason
+          <select v-model="reason" required>
+            <option value="" disabled>Select a reason</option>
+            <option v-for="item in reasons" :key="item" :value="item">{{ item }}</option>
+          </select>
+        </label>
+
+        <label v-if="reason === 'Other'">
+          Other reason
+          <textarea v-model.trim="otherReason" rows="3" maxlength="1000" required></textarea>
+        </label>
+
+        <div v-if="selectedSubject" class="warning" :class="{ destructive: mode === 'delete_data' }">
+          <template v-if="mode === 'keep_data'">
+            Subject <strong>{{ selectedSubject.id }}</strong> will be dropped out. Existing data will remain
+            available for review and export, but no data can be added, edited, imported, or uploaded.
+          </template>
+          <template v-else>
+            Subject <strong>{{ selectedSubject.id }}</strong> will be dropped out and their data will be removed
+            from the active Case-e dataset. Exports, backups, DataLad/git-annex remotes, and externally hosted
+            files are not deleted.
+          </template>
+        </div>
+
+        <template v-if="mode === 'delete_data' && selectedSubject">
+          <label class="acknowledge">
+            <input v-model="acknowledged" type="checkbox" />
+            I understand that the active application data cannot be restored through Case-e.
+          </label>
+          <label>
+            Type <strong>{{ selectedSubject.id }}</strong> to confirm
+            <input v-model="confirmationId" autocomplete="off" />
+          </label>
+        </template>
+
+        <p v-if="error" class="error">{{ error }}</p>
+        <footer>
+          <button type="button" @click="mode = ''" :disabled="saving">Back</button>
+          <button type="button" @click="$emit('close')" :disabled="saving">Cancel</button>
+          <button class="confirm" :class="{ danger: mode === 'delete_data' }" :disabled="!canSubmit || saving">
+            {{ saving ? 'Processing…' : mode === 'delete_data' ? 'Delete subject data and drop out' : 'Confirm dropout' }}
+          </button>
+        </footer>
+      </form>
+    </section>
+  </div>
+</template>
+
+<script>
+const REASONS = [
+  "Withdrawal of consent", "Lost to follow-up", "Adverse event", "Investigator decision",
+  "Protocol deviation", "Non-compliance", "Disease progression", "Death",
+  "Administrative reason", "Other",
+];
+
+export default {
+  name: "SubjectDropoutDialog",
+  props: {
+    subjects: { type: Array, default: () => [] },
+    entries: { type: Array, default: () => [] },
+    files: { type: Array, default: () => [] },
+    saving: { type: Boolean, default: false },
+    error: { type: String, default: "" },
+  },
+  emits: ["close", "submit"],
+  data() {
+    return {
+      mode: "",
+      subjectIndex: null,
+      dropoutDate: new Date().toISOString().slice(0, 10),
+      reason: "",
+      otherReason: "",
+      acknowledged: false,
+      confirmationId: "",
+      reasons: REASONS,
+    };
+  },
+  computed: {
+    activeSubjects() {
+      return this.subjects.map((subject, index) => ({
+        ...subject,
+        index,
+        id: String(subject?.id || subject?.subject_id || `Subject ${index + 1}`),
+      })).filter((subject) => String(subject.status || "ACTIVE").toUpperCase() === "ACTIVE");
+    },
+    selectedSubject() {
+      return this.activeSubjects.find((item) => item.index === this.subjectIndex) || null;
+    },
+    entryCount() {
+      return this.entries.filter((item) => Number(item.subject_index) === this.subjectIndex).length;
+    },
+    fileCount() {
+      return this.files.filter((item) => Number(item.subject_index) === this.subjectIndex).length;
+    },
+    canSubmit() {
+      if (!this.selectedSubject || !this.dropoutDate || !this.reason) return false;
+      if (this.reason === "Other" && !this.otherReason) return false;
+      if (this.mode === "delete_data") {
+        return this.acknowledged && this.confirmationId.trim() === this.selectedSubject.id;
+      }
+      return true;
+    },
+  },
+  methods: {
+    submit() {
+      if (!this.canSubmit) return;
+      this.$emit("submit", {
+        subjectIndex: this.subjectIndex,
+        mode: this.mode,
+        dropout_date: this.dropoutDate,
+        reason: this.reason,
+        other_reason: this.reason === "Other" ? this.otherReason : null,
+        confirmation_subject_id: this.mode === "delete_data" ? this.confirmationId.trim() : null,
+      });
+    },
+  },
+};
+</script>
+
+<style scoped>
+.dropout-backdrop { position: fixed; inset: 0; z-index: 1200; background: rgba(15,23,42,.55); display: grid; place-items: center; padding: 24px; }
+.dropout-dialog { width: min(620px, 100%); max-height: 90vh; overflow: auto; background: white; border-radius: 12px; padding: 24px; box-shadow: 0 24px 70px rgba(0,0,0,.25); }
+.dropout-dialog h3 { margin-top: 0; }
+.choice { width: 100%; display: flex; flex-direction: column; gap: 5px; text-align: left; padding: 14px; margin: 10px 0; border: 1px solid #cbd5e1; border-radius: 8px; background: #f8fafc; }
+.danger-choice { border-color: #fca5a5; background: #fff7f7; }
+label { display: grid; gap: 6px; margin: 14px 0; font-weight: 600; }
+select, input, textarea { padding: 9px 10px; border: 1px solid #94a3b8; border-radius: 6px; font: inherit; }
+.subject-facts { display: flex; justify-content: space-between; gap: 12px; padding: 10px; background: #f1f5f9; border-radius: 6px; }
+.warning { padding: 12px; border-left: 4px solid #dc2626; background: #fff1f2; color: #991b1b; margin: 16px 0; }
+.destructive { border: 1px solid #dc2626; border-left-width: 5px; }
+.acknowledge { display: flex; grid-template-columns: auto 1fr; align-items: flex-start; font-weight: 500; }
+.error { color: #b91c1c; }
+footer { display: flex; justify-content: flex-end; gap: 8px; margin-top: 20px; }
+footer button { padding: 9px 13px; border-radius: 6px; border: 1px solid #94a3b8; }
+.confirm { background: #9f1239; color: white; border-color: #9f1239; }
+.danger { background: #b91c1c; }
+button:disabled { opacity: .55; cursor: not-allowed; }
+</style>

--- a/eCRF_frontend/src/components/SubjectDropoutDialog.vue
+++ b/eCRF_frontend/src/components/SubjectDropoutDialog.vue
@@ -16,8 +16,9 @@
       </template>
 
       <form v-else @submit.prevent="submit">
+        <p class="required-note"><span class="required-mark">*</span> Required fields</p>
         <label>
-          Subject ID
+          <span>Subject ID <span class="required-mark">*</span></span>
           <select v-model.number="subjectIndex" required>
             <option :value="null" disabled>Select a subject</option>
             <option v-for="item in activeSubjects" :key="item.index" :value="item.index">
@@ -32,12 +33,12 @@
         </div>
 
         <label>
-          Dropout date
+          <span>Dropout date <span class="required-mark">*</span></span>
           <input v-model="dropoutDate" type="date" required />
         </label>
 
         <label>
-          Dropout reason
+          <span>Dropout reason <span class="required-mark">*</span></span>
           <select v-model="reason" required>
             <option value="" disabled>Select a reason</option>
             <option v-for="item in reasons" :key="item" :value="item">{{ item }}</option>
@@ -45,7 +46,7 @@
         </label>
 
         <label v-if="reason === 'Other'">
-          Other reason
+          <span>Other reason <span class="required-mark">*</span></span>
           <textarea v-model.trim="otherReason" rows="3" maxlength="1000" required></textarea>
         </label>
 
@@ -63,12 +64,12 @@
 
         <template v-if="mode === 'delete_data' && selectedSubject">
           <label class="acknowledge">
-            <input v-model="acknowledged" type="checkbox" />
-            I understand that the active application data cannot be restored through Case-e.
+            <input v-model="acknowledged" type="checkbox" required />
+            <span>I understand that the active application data cannot be restored through Case-e. <span class="required-mark">*</span></span>
           </label>
           <label>
-            Type <strong>{{ selectedSubject.id }}</strong> to confirm
-            <input v-model="confirmationId" autocomplete="off" />
+            <span>Type <strong>{{ selectedSubject.id }}</strong> to confirm <span class="required-mark">*</span></span>
+            <input v-model="confirmationId" autocomplete="off" required />
           </label>
         </template>
 
@@ -160,8 +161,10 @@ export default {
 .dropout-backdrop { position: fixed; inset: 0; z-index: 1200; background: rgba(15,23,42,.55); display: grid; place-items: center; padding: 24px; }
 .dropout-dialog { width: min(620px, 100%); max-height: 90vh; overflow: auto; background: white; border-radius: 12px; padding: 24px; box-shadow: 0 24px 70px rgba(0,0,0,.25); }
 .dropout-dialog h3 { margin-top: 0; }
-.choice { width: 100%; display: flex; flex-direction: column; gap: 5px; text-align: left; padding: 14px; margin: 10px 0; border: 1px solid #cbd5e1; border-radius: 8px; background: #f8fafc; }
+.choice { width: 100%; display: flex; flex-direction: column; gap: 5px; text-align: left; padding: 14px; margin: 10px 0; border: 1px solid #cbd5e1; border-radius: 8px; background: #f8fafc; cursor: pointer; transition: background-color .15s ease, border-color .15s ease, box-shadow .15s ease; }
+.choice:hover, .choice:focus-visible { background: #eef2ff; border-color: #818cf8; box-shadow: 0 2px 10px rgba(79,70,229,.1); }
 .danger-choice { border-color: #fca5a5; background: #fff7f7; }
+.danger-choice:hover, .danger-choice:focus-visible { background: #ffe4e6; border-color: #fb7185; box-shadow: 0 2px 10px rgba(190,24,93,.1); }
 label { display: grid; gap: 6px; margin: 14px 0; font-weight: 600; }
 select, input, textarea { padding: 9px 10px; border: 1px solid #94a3b8; border-radius: 6px; font: inherit; }
 .subject-facts { display: flex; justify-content: space-between; gap: 12px; padding: 10px; background: #f1f5f9; border-radius: 6px; }
@@ -169,8 +172,10 @@ select, input, textarea { padding: 9px 10px; border: 1px solid #94a3b8; border-r
 .destructive { border: 1px solid #dc2626; border-left-width: 5px; }
 .acknowledge { display: flex; grid-template-columns: auto 1fr; align-items: flex-start; font-weight: 500; }
 .error { color: #b91c1c; }
+.required-note { margin: 0 0 8px; color: #64748b; font-size: 13px; }
+.required-mark { color: #dc2626; }
 footer { display: flex; justify-content: flex-end; gap: 8px; margin-top: 20px; }
-footer button { padding: 9px 13px; border-radius: 6px; border: 1px solid #94a3b8; }
+footer button { padding: 9px 13px; border-radius: 6px; border: 1px solid #94a3b8; cursor: pointer; }
 .confirm { background: #9f1239; color: white; border-color: #9f1239; }
 .danger { background: #b91c1c; }
 button:disabled { opacity: .55; cursor: not-allowed; }

--- a/eCRF_frontend/src/components/dataentry/StudyLegendDialogs.vue
+++ b/eCRF_frontend/src/components/dataentry/StudyLegendDialogs.vue
@@ -25,6 +25,8 @@
           <li><span class="legend-swatch swatch-partial"></span> Partial — some fields filled.</li>
           <li><span class="legend-swatch swatch-complete"></span> Complete — all assigned fields filled.</li>
           <li><span class="legend-swatch swatch-skipped"></span> Skipped — one or more required fields were skipped.</li>
+          <li><span class="legend-swatch swatch-dropped-retained"></span> Dropped out — existing data retained as read-only.</li>
+          <li><span class="legend-swatch swatch-dropped-deleted"></span> Dropped out — active application data deleted.</li>
         </ul>
       </div>
     </div>
@@ -111,6 +113,12 @@ export default {
 }
 .swatch-skipped {
   background: #ef4444;
+}
+.swatch-dropped-retained {
+  background: #818cf8;
+}
+.swatch-dropped-deleted {
+  background: #64748b;
 }
 .legend-explain li {
   display: flex;

--- a/eCRF_frontend/tests/importStudyRevisionToken.test.js
+++ b/eCRF_frontend/tests/importStudyRevisionToken.test.js
@@ -1,0 +1,179 @@
+/* eslint-env node */
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const babel = require("@babel/core");
+const { parse } = require("@vue/compiler-sfc");
+
+function loadImportStudy(axiosMock) {
+  const sourcePath = path.resolve(__dirname, "../src/components/ImportStudy.vue");
+  const source = fs.readFileSync(sourcePath, "utf8");
+  const { descriptor } = parse(source, { filename: sourcePath });
+  const transformed = babel.transformSync(descriptor.script.content, {
+    filename: sourcePath,
+    cwd: path.resolve(__dirname, ".."),
+    babelrc: false,
+    configFile: false,
+    plugins: ["@babel/plugin-transform-modules-commonjs"],
+  }).code;
+  const loaded = { exports: {} };
+  const requireMock = (request) => {
+    if (request === "axios") return axiosMock;
+    if (request === "xlsx") return { read: () => ({}), utils: {} };
+    if (request === "papaparse") return {};
+    if (request === "js-yaml") return {};
+    if (request === "vuex") return { useStore: () => ({}) };
+    if (request.includes("assets/styles/icons")) return {};
+    return {};
+  };
+  new Function("require", "module", "exports", transformed)(requireMock, loaded, loaded.exports);
+  return { component: loaded.exports.default, source };
+}
+
+const item = {
+  subject_index: 0,
+  visit_index: 4,
+  group_index: 0,
+  data: { imported_fields: { weight: 70 } },
+  skipped_required_flags: [],
+};
+
+(async () => {
+  const calls = [];
+  const axiosMock = {
+    async get(url, config) {
+      calls.push({ method: "get", url, config });
+      return { data: { revision_token: "empty-slot-token" } };
+    },
+    async post(url, data, config) {
+      calls.push({ method: "post", url, data, config });
+      return { data: { id: 1 } };
+    },
+  };
+  const loaded = loadImportStudy(axiosMock);
+  const component = loaded.component;
+  assert.match(loaded.source, /Field schema JSON/);
+  assert.match(loaded.source, /Download example JSON/);
+  await component.methods.postImportedEntry.call({ token: "auth-token" }, 11, item);
+
+  assert.equal(calls.length, 2);
+  assert.equal(calls[0].method, "get");
+  assert.equal(calls[0].url, "/forms/studies/11/slot-data");
+  assert.deepEqual(calls[0].config.params, {
+    subject_index: 0,
+    visit_index: 4,
+    group_index: 0,
+  });
+  assert.equal(calls[1].method, "post");
+  assert.equal(calls[1].url, "/forms/studies/11/data");
+  assert.equal(calls[1].config.params.expected_revision_token, "empty-slot-token");
+  assert.equal(calls[1].config.params.audit_label, "Study Data Import");
+
+  const legacyCalls = [];
+  const legacyAxiosMock = {
+    async get() {
+      const error = new Error("Not found");
+      error.response = { status: 404 };
+      throw error;
+    },
+    async post(url, data, config) {
+      legacyCalls.push({ url, data, config });
+    },
+  };
+  const legacyComponent = loadImportStudy(legacyAxiosMock).component;
+  await legacyComponent.methods.postImportedEntry.call({ token: "auth-token" }, 12, item);
+  assert.equal(legacyCalls.length, 1);
+  assert.equal(legacyCalls[0].config.params.expected_revision_token, undefined);
+
+  const methods = component.methods;
+  const inferenceContext = {
+    isStrictDateValue: methods.isStrictDateValue,
+  };
+  assert.equal(methods.inferFieldType.call(inferenceContext, ["SITE-01", "SITE-02"]), "text");
+  assert.equal(methods.inferFieldType.call(inferenceContext, ["2025-01-01", "2025-12-31"]), "date");
+  assert.equal(methods.inferFieldType.call(inferenceContext, ["Yes", "No"]), "checkbox");
+  assert.equal(methods.isStrictDateValue("2025-02-29"), false);
+
+  const normalizedSchema = methods.normalizeFieldSchemaDocument({
+    version: 1,
+    fields: [
+      {
+        column: "Assessment Date",
+        type: "date",
+        section: "Visit Information",
+        constraints: { dateFormat: "yyyy-MM-dd" },
+      },
+      { column: "Site Code", type: "text", section: "Visit Information", required: true },
+      { column: "Pain Score", type: "integer", min: 0, max: 10 },
+      { column: "Adverse Event", type: "boolean" },
+    ],
+  });
+  assert.equal(normalizedSchema.fields[1].constraints.required, true);
+  assert.equal(normalizedSchema.fields[2].type, "number");
+  assert.equal(normalizedSchema.fields[2].constraints.max, 10);
+  assert.equal(normalizedSchema.fields[3].type, "checkbox");
+
+  const schemaContext = {
+    fieldSchema: normalizedSchema,
+    headers: ["Subject ID", "Group", "Visit", "Assessment Date", "Site Code", "Pain Score", "Adverse Event"],
+    mapping: {
+      subject: { idCol: "Subject ID", dateCol: "Assessment Date" },
+      group: { nameCol: "Group" },
+      visit: { nameCol: "Visit" },
+      otherCols: [],
+    },
+    otherFieldCandidates: ["Assessment Date", "Site Code", "Pain Score", "Adverse Event"],
+    fieldSchemaError: "",
+    fieldSchemaAppliedCount: 0,
+    otherAllSelected: false,
+  };
+  methods.applyFieldSchemaToCurrentHeaders.call(schemaContext);
+  assert.deepEqual(schemaContext.mapping.otherCols, [
+    "Assessment Date", "Site Code", "Pain Score", "Adverse Event",
+  ]);
+  assert.equal(schemaContext.fieldSchemaAppliedCount, 4);
+
+  const modelContext = {
+    mapping: { otherCols: schemaContext.mapping.otherCols },
+    rows: [{
+      "Assessment Date": "2025-01-01",
+      "Site Code": "SITE-01",
+      "Pain Score": "7",
+      "Adverse Event": "No",
+    }],
+    columnMeta: new Map(schemaContext.mapping.otherCols.map((column) => [column, {
+      section: "Imported Fields",
+      field: column,
+      name: column.toLowerCase().replace(/\s+/g, "_"),
+    }])),
+    fieldSchema: normalizedSchema,
+    fieldSchemaDefinitionForColumn(column) {
+      return methods.fieldSchemaDefinitionForColumn.call(this, column);
+    },
+    inferFieldType(samples) {
+      return methods.inferFieldType.call(inferenceContext, samples);
+    },
+  };
+  const selectedModels = methods.buildSelectedModels.call(modelContext);
+  const importedFields = selectedModels.flatMap((section) => section.fields);
+  assert.equal(importedFields.find((field) => field.name === "site_code").type, "text");
+  assert.equal(importedFields.find((field) => field.name === "assessment_date").constraints.dateFormat, "yyyy-MM-dd");
+  assert.equal(importedFields.find((field) => field.name === "adverse_event").type, "checkbox");
+
+  modelContext.normalizeImportedFieldValue = methods.normalizeImportedFieldValue;
+  const packed = methods.packRowDataToDict.call(modelContext, modelContext.rows[0]);
+  assert.equal(packed["Visit Information"].assessment_date, "2025-01-01");
+  assert.equal(packed["Visit Information"].site_code, "SITE-01");
+  assert.equal(packed["Imported Fields"].pain_score, 7);
+  assert.equal(packed["Imported Fields"].adverse_event, false);
+
+  assert.throws(
+    () => methods.normalizeFieldSchemaDocument({ fields: [{ column: "Site Code", type: "mystery" }] }),
+    /Unsupported type/
+  );
+
+  console.log("Import Study revision-token regression tests passed");
+})().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/eCRF_frontend/tests/studyViewPerformanceRegression.test.js
+++ b/eCRF_frontend/tests/studyViewPerformanceRegression.test.js
@@ -1,0 +1,110 @@
+/* eslint-env node */
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const babel = require("@babel/core");
+const { parse } = require("@vue/compiler-sfc");
+
+function loadVueComponent(relativePath) {
+  const sourcePath = path.resolve(__dirname, relativePath);
+  const source = fs.readFileSync(sourcePath, "utf8");
+  const { descriptor } = parse(source, { filename: sourcePath });
+  const transformed = babel.transformSync(descriptor.script.content, {
+    filename: sourcePath,
+    cwd: path.resolve(__dirname, ".."),
+    babelrc: false,
+    configFile: false,
+    plugins: ["@babel/plugin-transform-modules-commonjs"],
+  }).code;
+  const loaded = { exports: {} };
+  const requireMock = (request) => {
+    if (request === "axios") return {};
+    if (request.includes("uploadedFiles")) {
+      return {
+        collectUploadedFilesForSlot: () => [],
+        inferUploadedFileFieldContext: () => null,
+        normalizeUploadedFiles: () => [],
+        uploadedFileId: () => null,
+        uploadedFileName: () => "",
+      };
+    }
+    return {};
+  };
+  new Function("require", "module", "exports", transformed)(requireMock, loaded, loaded.exports);
+  return { component: loaded.exports.default, source };
+}
+
+const loadedDashboard = loadVueComponent("../src/components/StudyDataDashboard.vue");
+const dashboard = loadedDashboard.component;
+assert.match(loadedDashboard.source, /v-if="isBootstrapping \|\| isLoadingEntries"/);
+assert.match(loadedDashboard.source, /class="dashboard-loading-spinner"/);
+const methods = dashboard.methods;
+const proxiedStudy = new Proxy({ metadata: { id: 12 }, content: { study_data: { subjects: [] } } }, {});
+const clonedStudy = methods.cloneStudyPayload(proxiedStudy);
+assert.deepEqual(clonedStudy, proxiedStudy);
+assert.notEqual(clonedStudy, proxiedStudy);
+
+const entries = [
+  { id: 1, subject_index: 0, visit_index: 0, group_index: 0, form_version: 1, data: [["v1"]] },
+  { id: 2, subject_index: 0, visit_index: 0, group_index: 0, form_version: 2, data: [["v2"]] },
+  { id: 3, subject_index: 0, visit_index: 0, group_index: 0, form_version: 3, data: [["v3"]] },
+  { id: 4, subject_index: 1, visit_index: 0, group_index: 0, form_version: 1, data: [["other"]] },
+];
+const dashboardContext = {
+  entries,
+  selectedVersion: 2,
+  entryIndexCache: new WeakMap(),
+  entrySlotKey: methods.entrySlotKey,
+  buildEntrySlotIndex: methods.buildEntrySlotIndex,
+  entrySlotIndexFor: methods.entrySlotIndexFor,
+};
+Object.defineProperty(dashboardContext, "currentEntrySlotIndex", {
+  get() {
+    return methods.buildEntrySlotIndex.call(dashboardContext, entries);
+  },
+});
+
+assert.equal(methods.findBestEntryFromEntries.call(dashboardContext, entries, 0, 0, 0).id, 2);
+dashboardContext.selectedVersion = 4;
+assert.equal(methods.findBestEntryFromEntries.call(dashboardContext, entries, 0, 0, 0).id, 3);
+dashboardContext.selectedVersion = 0;
+assert.equal(methods.findBestEntryFromEntries.call(dashboardContext, entries, 0, 0, 0).id, 3);
+assert.equal(methods.findBestEntryFromEntries.call(dashboardContext, entries, 1, 0, 0).id, 4);
+assert.equal(methods.findBestEntryFromEntries.call(dashboardContext, entries, "0", 0, 0), null);
+
+function legacyFindBest(slotEntries, targetVersion) {
+  const exact = slotEntries.find((entry) => Number(entry.form_version) === Number(targetVersion));
+  if (exact) return exact;
+  const atOrBefore = slotEntries
+    .filter((entry) => Number(entry.form_version) <= Number(targetVersion))
+    .sort((a, b) => Number(b.form_version) - Number(a.form_version))[0];
+  if (atOrBefore) return atOrBefore;
+  return [...slotEntries].sort((a, b) => Number(b.form_version) - Number(a.form_version))[0];
+}
+
+const primarySlotEntries = entries.filter(
+  (entry) => entry.subject_index === 0 && entry.visit_index === 0 && entry.group_index === 0
+);
+[-1, 0, 1, 2, 3, 4, 99].forEach((targetVersion) => {
+  dashboardContext.selectedVersion = targetVersion;
+  const indexed = methods.findBestEntryFromEntries.call(dashboardContext, entries, 0, 0, 0);
+  const legacy = legacyFindBest(primarySlotEntries, targetVersion);
+  assert.equal(indexed.id, legacy.id);
+});
+
+const studyView = loadVueComponent("../src/components/StudyView.vue").component;
+let nextCalls = 0;
+const routeContext = {
+  activeTab: "meta",
+  tabs: [{ key: "meta" }, { key: "viewdata" }],
+};
+studyView.beforeRouteUpdate.call(
+  routeContext,
+  { params: { id: "12" }, query: { tab: "viewdata" } },
+  { params: { id: "12" }, query: { tab: "meta" } },
+  () => { nextCalls += 1; }
+);
+assert.equal(routeContext.activeTab, "viewdata");
+assert.equal(nextCalls, 1);
+
+console.log("Study View performance regression tests passed");

--- a/tests/test_hybrid_bulk_import.py
+++ b/tests/test_hybrid_bulk_import.py
@@ -1,0 +1,182 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from eCRF_backend import forms_hybrid, models, schemas
+from eCRF_backend.datalad_repo import DataladStudyRepo
+
+
+def _entry(subject_index, visit_index, group_index=0):
+    return {
+        "subject_index": subject_index,
+        "visit_index": visit_index,
+        "group_index": group_index,
+        "data": {"Imported Fields": {"value": f"{subject_index}-{visit_index}"}},
+        "skipped_required_flags": [],
+    }
+
+
+def test_repo_bulk_save_writes_all_entries_with_one_datalad_save(tmp_path, monkeypatch):
+    repo = DataladStudyRepo()
+    paths = SimpleNamespace(dataset_path=tmp_path)
+    save_calls = []
+    audit_calls = []
+
+    monkeypatch.setattr(repo, "ensure_dataset", lambda *_args, **_kwargs: paths)
+    monkeypatch.setattr(repo, "list_entries", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(
+        repo,
+        "_entry_path",
+        lambda _paths, **kwargs: tmp_path / f"entry_{int(kwargs['entry_id']):09d}.json",
+    )
+    monkeypatch.setattr(repo, "_resolve_subject_visit_group_labels", lambda *_args, **_kwargs: {})
+    monkeypatch.setattr(repo, "_append_audit", lambda *_args, **kwargs: audit_calls.append(kwargs))
+    monkeypatch.setattr(repo, "save", lambda *args, **_kwargs: save_calls.append(args))
+
+    written = repo.save_entries_bulk(
+        study_id=11,
+        study_name="Bulk import study",
+        form_version=1,
+        entries=[_entry(0, 0), _entry(0, 1), _entry(1, 0)],
+        actor="admin@example.test",
+        actor_name="Admin User",
+        user_id=1,
+        audit_label="Study Data Import",
+    )
+
+    assert [row["id"] for row in written] == [1, 2, 3]
+    assert len(save_calls) == 1
+    assert "count=3" in save_calls[0][1]
+    assert len(audit_calls) == 3
+    stored = [
+        json.loads(path.read_text(encoding="utf-8"))
+        for path in sorted(tmp_path.glob("entry_*.json"))
+    ]
+    assert stored == written
+
+
+@pytest.mark.parametrize(
+    "existing, entries, message",
+    [
+        ([_entry(0, 0) | {"id": 7, "form_version": 1}], [_entry(0, 0)], "already contains data"),
+        ([], [_entry(0, 0), _entry(0, 0)], "more than one row"),
+    ],
+)
+def test_repo_bulk_save_rejects_occupied_or_duplicate_slots_atomically(
+    tmp_path,
+    monkeypatch,
+    existing,
+    entries,
+    message,
+):
+    repo = DataladStudyRepo()
+    paths = SimpleNamespace(dataset_path=tmp_path)
+    save_calls = []
+
+    monkeypatch.setattr(repo, "ensure_dataset", lambda *_args, **_kwargs: paths)
+    monkeypatch.setattr(repo, "list_entries", lambda *_args, **_kwargs: existing)
+    monkeypatch.setattr(repo, "save", lambda *args, **_kwargs: save_calls.append(args))
+
+    with pytest.raises(ValueError, match=message):
+        repo.save_entries_bulk(
+            study_id=11,
+            study_name="Bulk import study",
+            form_version=1,
+            entries=entries,
+            actor="admin@example.test",
+        )
+
+    assert save_calls == []
+    assert list(tmp_path.glob("entry_*.json")) == []
+
+
+class _Query:
+    def __init__(self, value):
+        self.value = value
+
+    def filter(self, *_args, **_kwargs):
+        return self
+
+    def first(self):
+        return self.value
+
+
+class _Db:
+    def __init__(self, metadata):
+        self.metadata = metadata
+
+    def query(self, model):
+        assert model is models.StudyMetadata
+        return _Query(self.metadata)
+
+
+def test_hybrid_bulk_route_uses_repo_batch_and_returns_legacy_shape(monkeypatch):
+    metadata = SimpleNamespace(id=11, study_name="Bulk import study", status="PUBLISHED")
+    content = SimpleNamespace(study_data={"selectedModels": []})
+    user = SimpleNamespace(id=1, email="admin@example.test", username="admin", profile=None)
+    captured = {}
+
+    monkeypatch.setattr(forms_hybrid, "_assert_has_study_permission", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(forms_hybrid, "_assert_not_locked_by_other", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(forms_hybrid, "_resolve_form_version_or_400", lambda *_args, **_kwargs: 1)
+    monkeypatch.setattr(forms_hybrid, "_get_content_row_or_404", lambda *_args, **_kwargs: content)
+
+    def save_entries_bulk(**kwargs):
+        captured.update(kwargs)
+        return [{"id": 1}, {"id": 2}]
+
+    monkeypatch.setattr(forms_hybrid.repo, "save_entries_bulk", save_entries_bulk)
+
+    response = forms_hybrid.bulk_insert_data(
+        study_id=11,
+        payload=schemas.BulkPayload(
+            entries=[
+                schemas.StudyDataEntryCreate(**_entry(0, 0)),
+                schemas.StudyDataEntryCreate(**_entry(0, 1)),
+            ]
+        ),
+        version=None,
+        create_bids=False,
+        audit_label=None,
+        db=_Db(metadata),
+        current_user=user,
+    )
+
+    assert response == {"inserted": 2, "failed": 0, "errors": []}
+    assert captured["study_id"] == 11
+    assert captured["form_version"] == 1
+    assert captured["require_empty_slots"] is True
+    assert captured["audit_label"] == "Study Data Import"
+    assert len(captured["entries"]) == 2
+
+
+def test_hybrid_bulk_route_reports_slot_conflict(monkeypatch):
+    metadata = SimpleNamespace(id=11, study_name="Bulk import study", status="PUBLISHED")
+    content = SimpleNamespace(study_data={"selectedModels": []})
+    user = SimpleNamespace(id=1, email="admin@example.test", username="admin", profile=None)
+
+    monkeypatch.setattr(forms_hybrid, "_assert_has_study_permission", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(forms_hybrid, "_assert_not_locked_by_other", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(forms_hybrid, "_resolve_form_version_or_400", lambda *_args, **_kwargs: 1)
+    monkeypatch.setattr(forms_hybrid, "_get_content_row_or_404", lambda *_args, **_kwargs: content)
+    monkeypatch.setattr(
+        forms_hybrid.repo,
+        "save_entries_bulk",
+        lambda **_kwargs: (_ for _ in ()).throw(ValueError("slot already contains data")),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        forms_hybrid.bulk_insert_data(
+            study_id=11,
+            payload=schemas.BulkPayload(entries=[schemas.StudyDataEntryCreate(**_entry(0, 0))]),
+            version=None,
+            create_bids=False,
+            audit_label=None,
+            db=_Db(metadata),
+            current_user=user,
+        )
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.detail["conflict"] is True

--- a/tests/test_subject_dropout.py
+++ b/tests/test_subject_dropout.py
@@ -1,0 +1,106 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from eCRF_backend.datalad_repo import DataladStudyRepo
+from eCRF_backend.forms_hybrid import (
+    _assert_subject_active,
+    _validate_subject_identity_and_status_update,
+)
+
+
+def _write_json(path, payload):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_active_subject_guard_accepts_legacy_subject_and_blocks_dropout():
+    assert _assert_subject_active({"subjects": [{"id": "SUB-001"}]}, 0)["id"] == "SUB-001"
+
+    with pytest.raises(HTTPException) as exc:
+        _assert_subject_active(
+            {
+                "subjects": [{
+                    "id": "SUB-002",
+                    "status": "DROPPED_DATA_RETAINED",
+                    "dropout_date": "2026-08-06",
+                }]
+            },
+            0,
+        )
+    assert exc.value.status_code == 409
+    assert "SUB-002" in exc.value.detail
+
+
+def test_generic_study_update_cannot_remove_reorder_or_change_dropout_status():
+    old = {"subjects": [{"id": "SUB-001"}, {"id": "SUB-002", "status": "DROPPED_DATA_RETAINED"}]}
+
+    with pytest.raises(HTTPException, match="cannot be removed"):
+        _validate_subject_identity_and_status_update(old, {"subjects": old["subjects"][:1]})
+    with pytest.raises(HTTPException, match="positions cannot be changed"):
+        _validate_subject_identity_and_status_update(old, {"subjects": list(reversed(old["subjects"]))})
+    with pytest.raises(HTTPException, match="Dropped subjects cannot be modified"):
+        _validate_subject_identity_and_status_update(
+            old,
+            {"subjects": [{"id": "SUB-001"}, {"id": "SUB-002", "status": "DROPPED_DATA_RETAINED", "group": "B"}]},
+        )
+
+
+def test_delete_subject_active_data_removes_only_target_and_invalidates_links(tmp_path, monkeypatch):
+    repo = DataladStudyRepo()
+    canonical = tmp_path / "canonical"
+    paths = SimpleNamespace(
+        dataset_path=tmp_path,
+        entries_dir=canonical / "entries",
+        files_dir=canonical / "files",
+        shares_dir=canonical / "shared_links",
+    )
+    paths.entries_dir.mkdir(parents=True)
+    paths.files_dir.mkdir(parents=True)
+    paths.shares_dir.mkdir(parents=True)
+    monkeypatch.setattr(repo, "ensure_dataset", lambda *_args, **_kwargs: paths)
+    monkeypatch.setattr(repo, "save", lambda *_args, **_kwargs: None)
+    audits = []
+    monkeypatch.setattr(repo, "_append_audit", lambda *_args, **kwargs: audits.append(kwargs))
+
+    _write_json(paths.entries_dir / "entry_000000001.json", {"id": 1, "subject_index": 0})
+    _write_json(paths.entries_dir / "entry_000000002.json", {"id": 2, "subject_index": 1})
+    payload = paths.files_dir / "sub-0" / "scan.bin"
+    payload.parent.mkdir(parents=True)
+    payload.write_bytes(b"subject zero")
+    _write_json(paths.files_dir / "file_000000001.json", {
+        "id": 1,
+        "study_id": 11,
+        "subject_index": 0,
+        "storage_option": "local",
+        "file_path": str(payload.relative_to(tmp_path)),
+    })
+    _write_json(paths.files_dir / "file_000000002.json", {
+        "id": 2,
+        "study_id": 11,
+        "subject_index": 1,
+        "storage_option": "url",
+        "file_path": "https://example.org/keep",
+    })
+    _write_json(paths.shares_dir / "target.json", {"subject_index": 0, "used_count": 1, "max_uses": 10})
+    _write_json(paths.shares_dir / "keep.json", {"subject_index": 1, "used_count": 0, "max_uses": 10})
+
+    counts = repo.delete_subject_active_data(
+        study_id=11,
+        study_name="Dropout test",
+        subject_index=0,
+        audit_payload={"subject_raw": "SUB-001"},
+    )
+
+    assert counts == {"entries_deleted": 1, "files_deleted": 1, "shared_links_revoked": 1}
+    assert not (paths.entries_dir / "entry_000000001.json").exists()
+    assert (paths.entries_dir / "entry_000000002.json").exists()
+    assert not payload.exists()
+    assert (paths.files_dir / "file_000000002.json").exists()
+    invalidated = json.loads((paths.shares_dir / "target.json").read_text())
+    assert invalidated["max_uses"] == invalidated["used_count"] == 1
+    assert json.loads((paths.shares_dir / "keep.json").read_text())["max_uses"] == 10
+    assert audits[0]["action"] == "subject_dropped_delete_data"
+    assert audits[0]["payload"]["entries_deleted"] == 1

--- a/tests/test_subject_dropout.py
+++ b/tests/test_subject_dropout.py
@@ -6,6 +6,7 @@ from fastapi import HTTPException
 
 from eCRF_backend.datalad_repo import DataladStudyRepo
 from eCRF_backend.forms_hybrid import (
+    _assert_entry_subject_update_allowed,
     _assert_subject_active,
     _validate_subject_identity_and_status_update,
 )
@@ -46,6 +47,39 @@ def test_generic_study_update_cannot_remove_reorder_or_change_dropout_status():
             old,
             {"subjects": [{"id": "SUB-001"}, {"id": "SUB-002", "status": "DROPPED_DATA_RETAINED", "group": "B"}]},
         )
+
+
+def test_entry_update_validates_existing_owner_and_prevents_subject_reassignment():
+    study_data = {
+        "subjects": [
+            {"id": "SUB-001", "status": "DROPPED_DATA_RETAINED", "dropout_date": "2026-08-06"},
+            {"id": "SUB-002", "status": "ACTIVE"},
+            {"id": "SUB-003", "status": "ACTIVE"},
+        ]
+    }
+
+    with pytest.raises(HTTPException) as dropped_owner:
+        _assert_entry_subject_update_allowed(
+            study_data,
+            {"id": 77, "subject_index": 0},
+            requested_subject_index=1,
+        )
+    assert dropped_owner.value.status_code == 409
+    assert "SUB-001" in dropped_owner.value.detail
+
+    with pytest.raises(HTTPException, match="cannot be moved") as reassignment:
+        _assert_entry_subject_update_allowed(
+            study_data,
+            {"id": 78, "subject_index": 1},
+            requested_subject_index=2,
+        )
+    assert reassignment.value.status_code == 409
+
+    _assert_entry_subject_update_allowed(
+        study_data,
+        {"id": 78, "subject_index": 1},
+        requested_subject_index=1,
+    )
 
 
 def test_delete_subject_active_data_removes_only_target_and_invalidates_links(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Adds a controlled subject-dropout workflow for study administrators and authors. Subjects can be dropped while retaining read-only data, or dropped with their active application data and uploaded-file references removed.

The workflow preserves subject IDs and indexes, prevents future data entry and ID reuse, invalidates shared links, records audit events, and provides administrator-only reactivation for data-retained dropouts. The matrix includes clear dropout states, filters, confirmation safeguards, and analysis counts.


