### PR TITLE
Update study export options

### DIFF
--- a/eCRF_backend/forms_hybrid.py
+++ b/eCRF_backend/forms_hybrid.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, HTTPException, Depends, Query, UploadFile, File, Form, Body, Request, status
 from fastapi.responses import FileResponse, RedirectResponse
+from starlette.background import BackgroundTask
 
 from sqlalchemy.orm import Session
 
@@ -22,6 +23,7 @@ from .versions import VersionManager, normalize_study_data_ids
 from .settings import get_settings
 from .entry_progress import calculate_overall_entry_progress
 from .compliance import build_compliance_summary
+from .study_export import ExportOptions, build_analysis_export
 
 router = APIRouter(prefix="/forms", tags=["forms"])
 repo = DataladStudyRepo()
@@ -1149,6 +1151,98 @@ def download_full_study(
         path=str(zip_path),
         filename=zip_name,
         media_type="application/zip",
+    )
+
+
+def _export_int_set(value: Optional[str], *, field: str) -> Optional[set[int]]:
+    if value is None or not str(value).strip():
+        return None
+    output = set()
+    try:
+        for item in str(value).split(","):
+            output.add(int(item.strip()))
+    except (TypeError, ValueError):
+        raise HTTPException(status_code=400, detail=f"Invalid {field} selection")
+    if any(item < 0 for item in output):
+        raise HTTPException(status_code=400, detail=f"Invalid {field} selection")
+    return output
+
+
+@router.get("/studies/{study_id}/export")
+def export_study_analysis_package(
+    study_id: int,
+    versions: str = Query("latest", description="latest, all, or comma-separated version numbers"),
+    subject_indexes: Optional[str] = Query(None),
+    group_indexes: Optional[str] = Query(None),
+    visit_indexes: Optional[str] = Query(None),
+    include_data: bool = Query(True),
+    include_template: bool = Query(True),
+    include_files: bool = Query(False),
+    file_scope: str = Query("all", pattern="^(all|study|subject)$"),
+    include_audit: bool = Query(False),
+    audit_only: bool = Query(False),
+    db: Session = Depends(get_db),
+    user=Depends(get_current_user),
+):
+    """Download a filtered, human-labelled BIDS analysis package."""
+    meta = db.query(models.StudyMetadata).filter(models.StudyMetadata.id == study_id).first()
+    if not meta:
+        raise HTTPException(status_code=404, detail="Study not found")
+    _assert_owner_or_admin(meta, user)
+    content = _get_content_row_or_404(db, study_id)
+
+    template_rows = (
+        db.query(models.StudyTemplateVersion)
+        .filter(models.StudyTemplateVersion.study_id == study_id)
+        .order_by(models.StudyTemplateVersion.version.asc())
+        .all()
+    )
+    if not template_rows:
+        raise HTTPException(status_code=404, detail="No study template versions found")
+
+    available = {int(row.version): (row.schema or {}) for row in template_rows}
+    versions_value = str(versions or "latest").strip().lower()
+    if versions_value == "latest":
+        selected_versions = {max(available)}
+    elif versions_value == "all":
+        selected_versions = set(available)
+    else:
+        selected_versions = _export_int_set(versions, field="versions") or set()
+        missing = selected_versions - set(available)
+        if missing:
+            raise HTTPException(status_code=400, detail=f"Unknown study version(s): {', '.join(map(str, sorted(missing)))}")
+
+    options = ExportOptions(
+        versions=selected_versions,
+        subject_indexes=_export_int_set(subject_indexes, field="subjects"),
+        group_indexes=_export_int_set(group_indexes, field="groups"),
+        visit_indexes=_export_int_set(visit_indexes, field="visits"),
+        include_data=include_data,
+        include_template=include_template,
+        include_files=include_files,
+        file_scope=file_scope,
+        include_audit=include_audit,
+        audit_only=audit_only,
+    )
+    try:
+        zip_path, zip_name = build_analysis_export(
+            repo=repo,
+            study_id=study_id,
+            study_name=meta.study_name,
+            study_data=content.study_data or {},
+            schemas_by_version={version: available[version] for version in selected_versions},
+            options=options,
+        )
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Failed to build BIDS export: {exc}")
+
+    return FileResponse(
+        path=str(zip_path),
+        filename=zip_name,
+        media_type="application/zip",
+        background=BackgroundTask(shutil.rmtree, zip_path.parent, True),
     )
 
 @router.post("/studies/{study_id}/files", response_model=schemas.FileOut)

--- a/eCRF_backend/forms_hybrid.py
+++ b/eCRF_backend/forms_hybrid.py
@@ -1177,10 +1177,11 @@ def export_study_analysis_package(
     visit_indexes: Optional[str] = Query(None),
     include_data: bool = Query(True),
     include_template: bool = Query(True),
-    include_files: bool = Query(False),
+    include_files: bool = Query(True),
     file_scope: str = Query("all", pattern="^(all|study|subject)$"),
     include_audit: bool = Query(False),
     audit_only: bool = Query(False),
+    include_subject_folders: bool = Query(False),
     db: Session = Depends(get_db),
     user=Depends(get_current_user),
 ):
@@ -1223,6 +1224,7 @@ def export_study_analysis_package(
         file_scope=file_scope,
         include_audit=include_audit,
         audit_only=audit_only,
+        include_subject_folders=include_subject_folders,
     )
     try:
         zip_path, zip_name = build_analysis_export(

--- a/eCRF_backend/study_export.py
+++ b/eCRF_backend/study_export.py
@@ -1,0 +1,340 @@
+from __future__ import annotations
+
+import csv
+import json
+import re
+import shutil
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Set, Tuple
+
+from .datalad_repo import DataladStudyRepo
+
+
+def _slug(value: Any, fallback: str) -> str:
+    text = re.sub(r"[^A-Za-z0-9]+", "-", str(value or "").strip()).strip("-").lower()
+    return text[:80] or fallback
+
+
+def _display(obj: Dict[str, Any], fallback: str) -> str:
+    for key in ("label", "title", "name", "short_name", "id"):
+        value = str(obj.get(key) or "").strip()
+        if value:
+            return value
+    return fallback
+
+
+def _candidate_keys(obj: Dict[str, Any], index: int, prefix: str) -> List[str]:
+    values = [obj.get("_id"), obj.get("id"), obj.get("name"), obj.get("key"), obj.get("label"), obj.get("title"), f"{prefix}{index}"]
+    return [str(value).strip() for value in values if value is not None and str(value).strip()]
+
+
+def _read_key(data: Dict[str, Any], candidates: Sequence[str]) -> Any:
+    for key in candidates:
+        if key in data:
+            return data[key]
+    normalized = {str(key).strip().lower(): key for key in data}
+    for key in candidates:
+        match = normalized.get(key.strip().lower())
+        if match is not None:
+            return data[match]
+    return None
+
+
+def _cell(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bool):
+        return "Yes" if value else "No"
+    if isinstance(value, list):
+        return "; ".join(_cell(item) for item in value)
+    if isinstance(value, dict):
+        for key in ("file_name", "name", "url", "file_path"):
+            if value.get(key):
+                return str(value[key])
+        return json.dumps(value, ensure_ascii=False, sort_keys=True)
+    return str(value)
+
+
+def _column_name(value: Any, fallback: str) -> str:
+    text = re.sub(r"[^A-Za-z0-9]+", "_", str(value or "").strip()).strip("_").lower()
+    if not text:
+        text = fallback
+    if text[0].isdigit():
+        text = f"field_{text}"
+    return text[:80]
+
+
+def _bids_label(value: Any, fallback: str) -> str:
+    return re.sub(r"[^A-Za-z0-9]+", "", str(value or "").strip())[:64] or fallback
+
+
+def _safe_export_filename(value: Any, fallback: str) -> str:
+    name = Path(str(value or "")).name.strip()
+    name = re.sub(r"[^A-Za-z0-9._-]+", "_", name).strip("._")
+    return name[:160] or fallback
+
+
+def _field_catalog(schema: Dict[str, Any]) -> List[Tuple[int, int, Dict[str, Any], Dict[str, Any], str]]:
+    output = []
+    used: Dict[str, int] = {}
+    for section_index, section in enumerate(schema.get("selectedModels") or []):
+        section_name = _display(section, f"Section {section_index + 1}")
+        for field_index, field in enumerate(section.get("fields") or []):
+            field_name = field.get("name") or field.get("label") or field.get("title")
+            base = _column_name(field_name, f"section_{section_index + 1}_field_{field_index + 1}")
+            used[base] = used.get(base, 0) + 1
+            column = base if used[base] == 1 else f"{base}_{used[base]}"
+            output.append((section_index, field_index, section, field, column))
+    return output
+
+
+def _entry_values(entry: Dict[str, Any], catalog) -> Dict[str, str]:
+    data = entry.get("data") or {}
+    output: Dict[str, str] = {}
+    for section_index, field_index, section, field, column in catalog:
+        value = None
+        if isinstance(data, list):
+            section_data = data[section_index] if section_index < len(data) else []
+            if isinstance(section_data, list) and field_index < len(section_data):
+                value = section_data[field_index]
+        elif isinstance(data, dict):
+            section_data = _read_key(data, _candidate_keys(section, section_index, "s"))
+            if isinstance(section_data, dict):
+                value = _read_key(section_data, _candidate_keys(field, field_index, "f"))
+        output[column] = _cell(value)
+    return output
+
+
+def _latest_by_slot(entries: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    latest: Dict[Tuple[int, int, int, int], Dict[str, Any]] = {}
+    for row in entries:
+        try:
+            key = (int(row["subject_index"]), int(row["visit_index"]), int(row["group_index"]), int(row["form_version"]))
+        except (KeyError, TypeError, ValueError):
+            continue
+        previous = latest.get(key)
+        sort_key = (str(row.get("updated_at") or ""), str(row.get("created_at") or ""), int(row.get("id") or 0))
+        previous_key = (str(previous.get("updated_at") or ""), str(previous.get("created_at") or ""), int(previous.get("id") or 0)) if previous else None
+        if previous is None or sort_key > previous_key:
+            latest[key] = row
+    return sorted(latest.values(), key=lambda row: (int(row.get("form_version") or 0), int(row.get("subject_index") or 0), int(row.get("visit_index") or 0)))
+
+
+def _write_tsv(path: Path, rows: List[Dict[str, Any]], columns: Sequence[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(columns), delimiter="\t", extrasaction="ignore", lineterminator="\n")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _read_jsonl(paths: Iterable[Path]) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    for path in paths:
+        if not path.exists():
+            continue
+        for line in path.read_text(encoding="utf-8", errors="ignore").splitlines():
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(row, dict):
+                rows.append(row)
+    return rows
+
+
+@dataclass
+class ExportOptions:
+    versions: Optional[Set[int]] = None
+    subject_indexes: Optional[Set[int]] = None
+    group_indexes: Optional[Set[int]] = None
+    visit_indexes: Optional[Set[int]] = None
+    include_data: bool = True
+    include_template: bool = True
+    include_files: bool = False
+    file_scope: str = "all"
+    include_audit: bool = False
+    audit_only: bool = False
+
+
+def build_analysis_export(
+    *,
+    repo: DataladStudyRepo,
+    study_id: int,
+    study_name: str,
+    study_data: Dict[str, Any],
+    schemas_by_version: Dict[int, Dict[str, Any]],
+    options: ExportOptions,
+) -> Tuple[Path, str]:
+    """Build a human-labelled, analysis-ready BIDS ZIP."""
+    paths = repo.paths(study_id, study_name)
+    tmp_dir = Path(tempfile.mkdtemp(prefix=f"casee_export_{study_id}_"))
+    root_name = f"study-{study_id}-{_slug(study_name, 'study')}_bids-export"
+    root = tmp_dir / root_name
+    root.mkdir(parents=True)
+
+    subjects = study_data.get("subjects") or []
+    visits = study_data.get("visits") or []
+    groups = study_data.get("groups") or []
+    versions = sorted(options.versions or set(schemas_by_version))
+
+    def selected(row: Dict[str, Any]) -> bool:
+        try:
+            subject = int(row.get("subject_index"))
+            visit = int(row.get("visit_index"))
+            group = int(row.get("group_index"))
+            version = int(row.get("form_version"))
+        except (TypeError, ValueError):
+            return False
+        return (
+            version in versions
+            and (options.subject_indexes is None or subject in options.subject_indexes)
+            and (options.visit_indexes is None or visit in options.visit_indexes)
+            and (options.group_indexes is None or group in options.group_indexes)
+        )
+
+    dataset_description = {
+        "Name": study_name,
+        "BIDSVersion": "1.10.0",
+        "DatasetType": "raw",
+        "GeneratedBy": [{"Name": "case-e", "Description": "Human-labelled eCRF analysis export"}],
+    }
+    (root / "dataset_description.json").write_text(json.dumps(dataset_description, indent=2), encoding="utf-8")
+    (root / "CHANGES").write_text("1.0.0 Exported from case-e\n", encoding="utf-8")
+    (root / "README").write_text(
+        "case-e BIDS analysis export\n\nField and structure UUIDs are replaced by human-readable labels in all TSV data files.\n"
+        "The template JSON is retained separately when requested so the original study definition remains reproducible.\n",
+        encoding="utf-8",
+    )
+
+    participant_rows = []
+    for index, subject in enumerate(subjects):
+        if options.subject_indexes is not None and index not in options.subject_indexes:
+            continue
+        group_name = str(subject.get("group") or "")
+        group_index = next(
+            (group_idx for group_idx, group in enumerate(groups) if _display(group, "").strip().lower() == group_name.strip().lower()),
+            None,
+        )
+        if options.group_indexes is not None and group_index not in options.group_indexes:
+            continue
+        participant_rows.append({
+            "participant_id": f"sub-{_bids_label(subject.get('id'), f'{index + 1:05d}')}",
+            "group": group_name,
+        })
+    _write_tsv(root / "participants.tsv", participant_rows, ["participant_id", "group"])
+    (root / "participants.json").write_text(json.dumps({
+        "group": {"Description": "Study group display name"},
+    }, indent=2), encoding="utf-8")
+
+    entries = [row for row in _latest_by_slot(repo.list_entries(study_id, study_name)) if selected(row)]
+    if options.include_data and not options.audit_only:
+        for version in versions:
+            schema = schemas_by_version.get(version) or study_data
+            catalog = _field_catalog(schema)
+            columns = ["participant_id", "visit", "group", "study_version"] + [item[4] for item in catalog]
+            sidecar = {
+                "MeasurementToolMetadata": {
+                    "Description": f"case-e electronic case report form, study template version {version}"
+                },
+                "visit": {"LongName": "Visit", "Description": "Human-readable study visit name"},
+                "group": {"LongName": "Study group", "Description": "Human-readable study group name"},
+                "study_version": {"LongName": "Study template version", "Description": "case-e template version used for this entry"},
+            }
+            for _, _, section, field, column in catalog:
+                metadata = {
+                    "LongName": _display(field, column),
+                    "Description": str(field.get("description") or f"{_display(section, 'Form')} — {_display(field, column)}"),
+                }
+                constraints = field.get("constraints") or {}
+                if field.get("options") or constraints.get("options"):
+                    metadata["Levels"] = {str(value): str(value) for value in (field.get("options") or constraints.get("options") or [])}
+                sidecar[column] = metadata
+            rows = []
+            for entry in entries:
+                if int(entry.get("form_version") or 0) != version:
+                    continue
+                subject_index = int(entry.get("subject_index") or 0)
+                visit_index = int(entry.get("visit_index") or 0)
+                group_index = int(entry.get("group_index") or 0)
+                subject = subjects[subject_index] if subject_index < len(subjects) else {}
+                visit = visits[visit_index] if visit_index < len(visits) else {}
+                group = groups[group_index] if group_index < len(groups) else {}
+                subject_name = str(subject.get("id") or f"Subject {subject_index + 1}")
+                visit_name = _display(visit, f"Visit {visit_index + 1}")
+                group_name = _display(group, str(subject.get("group") or f"Group {group_index + 1}"))
+                row = {
+                    "participant_id": f"sub-{_bids_label(subject_name, f'{subject_index + 1:05d}')}",
+                    "visit": visit_name,
+                    "group": group_name,
+                    "study_version": version,
+                    **_entry_values(entry, catalog),
+                }
+                rows.append(row)
+            phenotype_name = f"ecrf_version_{version:03d}"
+            _write_tsv(root / "phenotype" / f"{phenotype_name}.tsv", rows, columns)
+            (root / "phenotype" / f"{phenotype_name}.json").write_text(
+                json.dumps(sidecar, ensure_ascii=False, indent=2), encoding="utf-8"
+            )
+
+    if options.include_template and not options.audit_only:
+        for version in versions:
+            schema = schemas_by_version.get(version)
+            if schema is not None:
+                target = root / "code" / f"study-template_version-{version}.json"
+                target.parent.mkdir(parents=True, exist_ok=True)
+                target.write_text(json.dumps(schema, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    if options.include_files and not options.audit_only:
+        manifest = []
+        for record in repo.list_files(study_id, study_name):
+            subject_index = record.get("subject_index")
+            is_study_file = subject_index is None
+            if record.get("form_version") is not None and int(record["form_version"]) not in versions:
+                continue
+            if options.file_scope == "study" and not is_study_file:
+                continue
+            if options.file_scope == "subject" and is_study_file:
+                continue
+            if not is_study_file and options.subject_indexes is not None and int(subject_index) not in options.subject_indexes:
+                continue
+            if record.get("visit_index") is not None and options.visit_indexes is not None and int(record["visit_index"]) not in options.visit_indexes:
+                continue
+            if record.get("group_index") is not None and options.group_indexes is not None and int(record["group_index"]) not in options.group_indexes:
+                continue
+            item = dict(record)
+            if str(record.get("storage_option") or "").lower() != "url" and record.get("file_path"):
+                source = (paths.dataset_path / str(record["file_path"])).resolve()
+                try:
+                    source.relative_to(paths.dataset_path.resolve())
+                except ValueError:
+                    source = Path()
+                if source.is_file():
+                    scope = "study" if is_study_file else f"sub-{_bids_label(subjects[int(subject_index)].get('id') if int(subject_index) < len(subjects) else subject_index, str(subject_index))}"
+                    filename = _safe_export_filename(record.get("file_name"), f"file-{record.get('id')}")
+                    target = root / "sourcedata" / scope / f"file-{record.get('id')}_{filename}"
+                    target.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.copy2(source, target)
+                    item["export_path"] = str(target.relative_to(root))
+            manifest.append(item)
+        manifest_path = root / "sourcedata" / "files_manifest.json"
+        manifest_path.parent.mkdir(parents=True, exist_ok=True)
+        manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    if options.include_audit or options.audit_only:
+        audit_paths = [paths.audit_system_study_dir / "events.jsonl"]
+        if paths.audit_subject_dir.exists():
+            for subject_dir in paths.audit_subject_dir.glob("subject_*"):
+                match = re.match(r"subject_(\d+)", subject_dir.name)
+                if options.subject_indexes is not None and (not match or int(match.group(1)) not in options.subject_indexes):
+                    continue
+                audit_paths.append(subject_dir / "events.jsonl")
+        audit_rows = _read_jsonl(audit_paths)
+        audit_target = root / "sourcedata" / "case-e" / "audit_log.jsonl"
+        audit_target.parent.mkdir(parents=True, exist_ok=True)
+        audit_target.write_text("".join(json.dumps(row, ensure_ascii=False) + "\n" for row in audit_rows), encoding="utf-8")
+
+    archive = shutil.make_archive(str(tmp_dir / root_name), "zip", root_dir=str(tmp_dir), base_dir=root_name)
+    return Path(archive), f"{root_name}.zip"

--- a/eCRF_backend/study_export.py
+++ b/eCRF_backend/study_export.py
@@ -107,6 +107,372 @@ def _entry_values(entry: Dict[str, Any], catalog) -> Dict[str, str]:
     return output
 
 
+def _entry_field_value(
+    entry: Dict[str, Any],
+    section_index: int,
+    field_index: int,
+    section: Dict[str, Any],
+    field: Dict[str, Any],
+) -> Any:
+    data = entry.get("data") or {}
+    if isinstance(data, list):
+        section_data = data[section_index] if section_index < len(data) else []
+        if isinstance(section_data, list) and field_index < len(section_data):
+            return section_data[field_index]
+        return None
+    if isinstance(data, dict):
+        section_data = _read_key(data, _candidate_keys(section, section_index, "s"))
+        if isinstance(section_data, dict):
+            return _read_key(section_data, _candidate_keys(field, field_index, "f"))
+    return None
+
+
+def _stable_id(obj: Dict[str, Any]) -> str:
+    return str(obj.get("_id") or obj.get("id") or obj.get("uuid") or "").strip()
+
+
+_VERSIONED_CONSTRAINT_KEYS = {
+    "required", "pattern", "min", "max", "minLength", "maxLength", "step",
+    "allowMultiple", "dominantOptions", "integerOnly", "dateFormat", "minDate",
+    "maxDate", "minTime", "maxTime", "hourCycle", "minDigits", "maxDigits",
+}
+
+
+def _normalized_options(options: Any) -> List[Any]:
+    if not isinstance(options, list):
+        return []
+    normalized = []
+    for option in options:
+        if isinstance(option, dict):
+            normalized.append({
+                "value": option.get("value") or option.get("label") or option.get("name") or option.get("title"),
+            })
+        else:
+            normalized.append(str(option))
+    return normalized
+
+
+def _structural_constraints(obj: Dict[str, Any]) -> Dict[str, Any]:
+    constraints = obj.get("constraints") or {}
+    return {key: constraints.get(key) for key in sorted(_VERSIONED_CONSTRAINT_KEYS) if key in constraints}
+
+
+def _field_export_signature(field: Dict[str, Any]) -> str:
+    """Return the form aspects that require separate data columns when changed."""
+    field_type = str(field.get("type") or "").lower()
+    signature: Dict[str, Any] = {
+        "name": str(field.get("name") or field.get("key") or "").strip(),
+        "type": field_type,
+        "constraints": _structural_constraints(field),
+    }
+    if field_type in {"select", "radio", "checkbox"}:
+        signature["options"] = _normalized_options(field.get("options") or [])
+    if field_type == "table":
+        config = field.get("tableConfig") or {}
+        signature["table"] = {
+            "mode": config.get("mode") or "2d",
+            "initialRows": int(config.get("initialRows") or 1),
+            "allowAddRows": bool(config.get("allowAddRows", True)),
+            "columns": [{
+                "id": _stable_id(column),
+                "key": str(column.get("key") or column.get("name") or "").strip(),
+                "type": str(column.get("type") or "").lower(),
+                "options": _normalized_options(column.get("options") or []),
+                "constraints": _structural_constraints(column),
+            } for column in (config.get("columns") or []) if isinstance(column, dict)],
+        }
+    return json.dumps(signature, ensure_ascii=False, sort_keys=True, default=str)
+
+
+def _table_rows(value: Any) -> List[Dict[str, Any]]:
+    rows = value.get("rows") if isinstance(value, dict) else value
+    if not isinstance(rows, list):
+        return []
+    return [row for row in rows if isinstance(row, dict)]
+
+
+def _latest_entry_by_subject_visit_version(entries: Iterable[Dict[str, Any]]) -> Dict[Tuple[int, int, int], Dict[str, Any]]:
+    latest: Dict[Tuple[int, int, int], Dict[str, Any]] = {}
+    for row in entries:
+        try:
+            key = (int(row["subject_index"]), int(row["visit_index"]), int(row["form_version"]))
+        except (KeyError, TypeError, ValueError):
+            continue
+        previous = latest.get(key)
+        sort_key = (str(row.get("updated_at") or ""), str(row.get("created_at") or ""), int(row.get("id") or 0))
+        previous_key = (
+            str(previous.get("updated_at") or ""),
+            str(previous.get("created_at") or ""),
+            int(previous.get("id") or 0),
+        ) if previous else None
+        if previous is None or sort_key > previous_key:
+            latest[key] = row
+    return latest
+
+
+def _combined_version_export(
+    *,
+    versions: Sequence[int],
+    schemas_by_version: Dict[int, Dict[str, Any]],
+    entries: Sequence[Dict[str, Any]],
+    subjects: Sequence[Dict[str, Any]],
+    visits: Sequence[Dict[str, Any]],
+) -> Tuple[List[Dict[str, Any]], List[str], Dict[str, Any]]:
+    """Build one wide phenotype table with one row per participant and visit."""
+    version_list = sorted(int(version) for version in versions)
+    lineages: Dict[Tuple[str, ...], Dict[str, Any]] = {}
+    lineage_order: List[Tuple[str, ...]] = []
+
+    for version in version_list:
+        schema = schemas_by_version.get(version) or {}
+        for section_index, section in enumerate(schema.get("selectedModels") or []):
+            for field_index, field in enumerate(section.get("fields") or []):
+                field_id = _stable_id(field)
+                key = ("id", field_id) if field_id else (
+                    "legacy", str(version), str(section_index), str(field_index)
+                )
+                if key not in lineages:
+                    lineages[key] = {"instances": {}}
+                    lineage_order.append(key)
+                lineages[key]["instances"][version] = (section_index, field_index, section, field)
+
+    used_bases: Dict[str, int] = {}
+    for key in lineage_order:
+        lineage = lineages[key]
+        latest_version = max(lineage["instances"])
+        latest_field = lineage["instances"][latest_version][3]
+        base = _column_name(
+            latest_field.get("name") or latest_field.get("label") or latest_field.get("title"),
+            "field",
+        )
+        used_bases[base] = used_bases.get(base, 0) + 1
+        lineage["base"] = base if used_bases[base] == 1 else f"{base}_{used_bases[base]}"
+
+    entry_index = _latest_entry_by_subject_visit_version(entries)
+    descriptors: List[Dict[str, Any]] = []
+    sidecar: Dict[str, Any] = {
+        "MeasurementToolMetadata": {
+            "Description": "case-e electronic case report form with selected study versions combined horizontally",
+            "VersionsIncluded": version_list,
+            "RowRule": "Exactly one row per participant_id and visit",
+            "TableRowMatching": "Structurally changed tables use version snapshots; row positions are not matched across versions",
+        },
+        "visit": {"LongName": "Visit", "Description": "Human-readable study visit name"},
+        "group": {"LongName": "Study group", "Description": "Current human-readable study group name"},
+    }
+
+    def add_descriptor(column: str, descriptor: Dict[str, Any], metadata: Dict[str, Any]) -> None:
+        descriptors.append({"column": column, **descriptor})
+        sidecar[column] = metadata
+
+    for key in lineage_order:
+        lineage = lineages[key]
+        instances = lineage["instances"]
+        base = lineage["base"]
+        latest_instance = instances[max(instances)]
+        latest_section, latest_field = latest_instance[2], latest_instance[3]
+        field_id = _stable_id(latest_field) or None
+        affected = (
+            len(instances) != len(version_list)
+            or len({_field_export_signature(instance[3]) for instance in instances.values()}) > 1
+        )
+        has_scalar = any(str(instance[3].get("type") or "").lower() != "table" for instance in instances.values())
+        has_table = any(str(instance[3].get("type") or "").lower() == "table" for instance in instances.values())
+
+        if has_scalar:
+            scalar_instances = {
+                version: instance for version, instance in instances.items()
+                if str(instance[3].get("type") or "").lower() != "table"
+            }
+            latest_scalar_version = max(scalar_instances)
+            latest_scalar_instance = scalar_instances[latest_scalar_version]
+            if not affected:
+                source_field = latest_scalar_instance[3]
+                metadata = {
+                    "LongName": _display(source_field, base),
+                    "Description": str(source_field.get("description") or f"{_display(latest_section, 'Form')} — {_display(source_field, base)}"),
+                    "StudyVersions": version_list,
+                    "VersionedBecauseFormChanged": False,
+                    "ValueSelection": "Latest available selected version",
+                    "SourceFieldID": _stable_id(source_field) or field_id,
+                    "SourceType": str(source_field.get("type") or ""),
+                }
+                constraints = source_field.get("constraints") or {}
+                options = source_field.get("options") or constraints.get("options") or []
+                if options:
+                    metadata["Levels"] = {str(value): str(value) for value in options}
+                add_descriptor(base, {
+                    "kind": "scalar_common", "instances": scalar_instances,
+                }, metadata)
+            else:
+                for version in version_list:
+                    instance = scalar_instances.get(version)
+                    available = instance is not None
+                    source_field = instance[3] if available else latest_scalar_instance[3]
+                    column = f"{base}__v{version:03d}"
+                    metadata = {
+                        "LongName": f"{_display(source_field, base)} — version {version}",
+                        "Description": str(source_field.get("description") or f"{_display(latest_section, 'Form')} — {_display(source_field, base)}"),
+                        "StudyVersion": version,
+                        "VersionedBecauseFormChanged": True,
+                        "FieldAvailableInVersion": available,
+                        "SourceFieldID": _stable_id(source_field) or field_id,
+                        "SourceType": str(source_field.get("type") or ""),
+                    }
+                    constraints = source_field.get("constraints") or {}
+                    options = source_field.get("options") or constraints.get("options") or []
+                    if options:
+                        metadata["Levels"] = {str(value): str(value) for value in options}
+                    add_descriptor(column, {
+                        "kind": "scalar_versioned", "version": version,
+                        "instance": instance,
+                    }, metadata)
+
+        if has_table:
+            table_columns: Dict[Tuple[str, ...], Dict[str, Any]] = {}
+            table_column_order: List[Tuple[str, ...]] = []
+            max_rows = 1
+            for version, instance in instances.items():
+                section_index, field_index, section, field = instance
+                if str(field.get("type") or "").lower() != "table":
+                    continue
+                for column_index, table_column in enumerate((field.get("tableConfig") or {}).get("columns") or []):
+                    table_column_id = _stable_id(table_column)
+                    natural_key = str(table_column.get("key") or table_column.get("name") or "").strip().lower()
+                    column_key = (
+                        ("id", table_column_id) if table_column_id
+                        else ("natural", natural_key) if natural_key
+                        else ("legacy", str(version), str(column_index))
+                    )
+                    if column_key not in table_columns:
+                        table_columns[column_key] = {"instances": {}}
+                        table_column_order.append(column_key)
+                    table_columns[column_key]["instances"][version] = (column_index, table_column)
+                for (subject_index, visit_index, entry_version), entry in entry_index.items():
+                    if entry_version != version:
+                        continue
+                    value = _entry_field_value(entry, section_index, field_index, section, field)
+                    max_rows = max(max_rows, len(_table_rows(value)))
+
+            used_table_bases: Dict[str, int] = {}
+            for column_key in table_column_order:
+                table_lineage = table_columns[column_key]
+                latest_column_version = max(table_lineage["instances"])
+                latest_table_column = table_lineage["instances"][latest_column_version][1]
+                table_base = _column_name(
+                    latest_table_column.get("key") or latest_table_column.get("name") or latest_table_column.get("label"),
+                    "column",
+                )
+                used_table_bases[table_base] = used_table_bases.get(table_base, 0) + 1
+                if used_table_bases[table_base] > 1:
+                    table_base = f"{table_base}_{used_table_bases[table_base]}"
+                table_lineage["base"] = table_base
+
+            table_instances = {
+                version: instance for version, instance in instances.items()
+                if str(instance[3].get("type") or "").lower() == "table"
+            }
+            if not affected:
+                for row_index in range(max_rows):
+                    for column_key in table_column_order:
+                        table_lineage = table_columns[column_key]
+                        source_column = table_lineage["instances"][max(table_lineage["instances"])][1]
+                        column = f"{base}__row{row_index + 1:02d}__{table_lineage['base']}"
+                        metadata = {
+                            "LongName": f"{_display(latest_field, base)} — row {row_index + 1}, {_display(source_column, table_lineage['base'])}",
+                            "Description": "Flattened repeating-table cell from the latest available selected version",
+                            "StudyVersions": version_list,
+                            "VersionedBecauseFormChanged": False,
+                            "ValueSelection": "Latest available selected version",
+                            "SourceFieldID": field_id,
+                            "SourceType": str(source_column.get("type") or ""),
+                            "TableRowNumber": row_index + 1,
+                            "SourceTableColumnID": _stable_id(source_column) or None,
+                        }
+                        add_descriptor(column, {
+                            "kind": "table_common", "instances": table_instances,
+                            "table_columns": table_lineage["instances"],
+                            "row_index": row_index,
+                        }, metadata)
+            else:
+                for version in version_list:
+                    field_instance = table_instances.get(version)
+                    table_available = field_instance is not None
+                    for row_index in range(max_rows):
+                        for column_key in table_column_order:
+                            table_lineage = table_columns[column_key]
+                            table_column_instance = table_lineage["instances"].get(version)
+                            available = bool(table_available and table_column_instance)
+                            source_column = table_column_instance[1] if table_column_instance else table_lineage["instances"][max(table_lineage["instances"])][1]
+                            column = f"{base}__v{version:03d}__row{row_index + 1:02d}__{table_lineage['base']}"
+                            metadata = {
+                                "LongName": f"{_display(latest_field, base)} — version {version}, row {row_index + 1}, {_display(source_column, table_lineage['base'])}",
+                                "Description": "Flattened repeating-table cell from an independent version snapshot",
+                                "StudyVersion": version,
+                                "VersionedBecauseFormChanged": True,
+                                "FieldAvailableInVersion": table_available,
+                                "TableColumnAvailableInVersion": available,
+                                "SourceFieldID": _stable_id(field_instance[3]) if field_instance else field_id,
+                                "SourceType": str(source_column.get("type") or ""),
+                                "TableRowNumber": row_index + 1,
+                                "SourceTableColumnID": _stable_id(source_column) or None,
+                            }
+                            add_descriptor(column, {
+                                "kind": "table_versioned", "version": version,
+                                "instance": field_instance,
+                                "table_column": table_column_instance,
+                                "row_index": row_index,
+                            }, metadata)
+
+    row_keys = sorted({(subject, visit) for subject, visit, _version in entry_index})
+    rows: List[Dict[str, Any]] = []
+    for subject_index, visit_index in row_keys:
+        subject = subjects[subject_index] if subject_index < len(subjects) else {}
+        visit = visits[visit_index] if visit_index < len(visits) else {}
+        subject_name = str(subject.get("id") or f"Subject {subject_index + 1}")
+        visit_name = _display(visit, f"Visit {visit_index + 1}")
+        group_name = str(subject.get("group") or "")
+        row: Dict[str, Any] = {
+            "participant_id": f"sub-{_bids_label(subject_name, f'{subject_index + 1:05d}')}",
+            "visit": visit_name,
+            "group": group_name,
+        }
+        for descriptor in descriptors:
+            value: Any = None
+            entry = None
+            instance = None
+            table_column_instance = None
+            if descriptor["kind"].endswith("_common"):
+                for version in reversed(version_list):
+                    candidate_entry = entry_index.get((subject_index, visit_index, version))
+                    candidate_instance = descriptor["instances"].get(version)
+                    if candidate_entry is not None and candidate_instance is not None:
+                        entry = candidate_entry
+                        instance = candidate_instance
+                        if descriptor["kind"] == "table_common":
+                            table_column_instance = descriptor["table_columns"].get(version)
+                        break
+            else:
+                entry = entry_index.get((subject_index, visit_index, descriptor["version"]))
+                instance = descriptor.get("instance")
+                table_column_instance = descriptor.get("table_column")
+            if entry is not None and instance is not None:
+                section_index, field_index, section, field = instance
+                value = _entry_field_value(entry, section_index, field_index, section, field)
+                if descriptor["kind"].startswith("table_"):
+                    table_rows = _table_rows(value)
+                    row_index = descriptor["row_index"]
+                    value = None
+                    if row_index < len(table_rows) and table_column_instance:
+                        column_index, table_column = table_column_instance
+                        value = _read_key(table_rows[row_index], _candidate_keys(table_column, column_index, "column_"))
+            row[descriptor["column"]] = _cell(value) if value is not None else "n/a"
+        rows.append(row)
+
+    columns = ["participant_id", "visit", "group"] + [descriptor["column"] for descriptor in descriptors]
+    return rows, columns, sidecar
+
+
 def _latest_by_slot(entries: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
     latest: Dict[Tuple[int, int, int, int], Dict[str, Any]] = {}
     for row in entries:
@@ -206,7 +572,13 @@ def build_analysis_export(
     (root / "CHANGES").write_text("1.0.0 Exported from case-e\n", encoding="utf-8")
     (root / "README").write_text(
         "case-e BIDS analysis export\n\nField and structure UUIDs are replaced by human-readable labels in all TSV data files.\n"
-        "The template JSON is retained separately when requested so the original study definition remains reproducible.\n",
+        "The template JSON is retained separately when requested so the original study definition remains reproducible.\n"
+        + (
+            "\nSelected study versions are combined in phenotype/ecrf.tsv. Each participant and visit appears once. "
+            "Unchanged fields remain single columns; only fields affected by a form change expand using __vNNN suffixes. "
+            "Repeating tables use __rowNN columns and become versioned only when their structure changes.\n"
+            if len(versions) > 1 else ""
+        ),
         encoding="utf-8",
     )
 
@@ -231,7 +603,30 @@ def build_analysis_export(
     }, indent=2), encoding="utf-8")
 
     entries = [row for row in _latest_by_slot(repo.list_entries(study_id, study_name)) if selected(row)]
-    if options.include_data and not options.audit_only:
+    if options.include_data and not options.audit_only and len(versions) > 1:
+        rows, columns, sidecar = _combined_version_export(
+            versions=versions,
+            schemas_by_version=schemas_by_version,
+            entries=entries,
+            subjects=subjects,
+            visits=visits,
+        )
+        _write_tsv(root / "phenotype" / "ecrf.tsv", rows, columns)
+        (root / "phenotype" / "ecrf.json").write_text(
+            json.dumps(sidecar, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
+        if options.include_subject_folders:
+            for row in rows:
+                participant_id = row["participant_id"]
+                visit_name = row["visit"]
+                session_id = f"ses-{_bids_label(visit_name, '01')}"
+                subject_name = f"{participant_id}_{session_id}_ecrf"
+                subject_dir = root / "sourcedata" / participant_id / session_id / "ecrf"
+                _write_tsv(subject_dir / f"{subject_name}.tsv", [row], columns)
+                (subject_dir / f"{subject_name}.json").write_text(
+                    json.dumps(sidecar, ensure_ascii=False, indent=2), encoding="utf-8"
+                )
+    elif options.include_data and not options.audit_only:
         for version in versions:
             schema = schemas_by_version.get(version) or study_data
             catalog = _field_catalog(schema)

--- a/eCRF_backend/study_export.py
+++ b/eCRF_backend/study_export.py
@@ -153,10 +153,11 @@ class ExportOptions:
     visit_indexes: Optional[Set[int]] = None
     include_data: bool = True
     include_template: bool = True
-    include_files: bool = False
+    include_files: bool = True
     file_scope: str = "all"
     include_audit: bool = False
     audit_only: bool = False
+    include_subject_folders: bool = False
 
 
 def build_analysis_export(
@@ -273,6 +274,15 @@ def build_analysis_export(
                     **_entry_values(entry, catalog),
                 }
                 rows.append(row)
+                if options.include_subject_folders:
+                    participant_id = row["participant_id"]
+                    session_id = f"ses-{_bids_label(visit_name, f'{visit_index + 1:02d}') }"
+                    subject_name = f"{participant_id}_{session_id}_version-{version:03d}_ecrf"
+                    subject_dir = root / "sourcedata" / participant_id / session_id / "ecrf"
+                    _write_tsv(subject_dir / f"{subject_name}.tsv", [row], columns)
+                    (subject_dir / f"{subject_name}.json").write_text(
+                        json.dumps(sidecar, ensure_ascii=False, indent=2), encoding="utf-8"
+                    )
             phenotype_name = f"ecrf_version_{version:03d}"
             _write_tsv(root / "phenotype" / f"{phenotype_name}.tsv", rows, columns)
             (root / "phenotype" / f"{phenotype_name}.json").write_text(
@@ -312,9 +322,24 @@ def build_analysis_export(
                 except ValueError:
                     source = Path()
                 if source.is_file():
-                    scope = "study" if is_study_file else f"sub-{_bids_label(subjects[int(subject_index)].get('id') if int(subject_index) < len(subjects) else subject_index, str(subject_index))}"
+                    if is_study_file:
+                        file_dir = root / "sourcedata" / "study"
+                    else:
+                        subject_number = int(subject_index)
+                        participant_id = f"sub-{_bids_label(subjects[subject_number].get('id') if subject_number < len(subjects) else subject_number, str(subject_number))}"
+                        file_dir = root / "sourcedata" / participant_id
+                        if options.include_subject_folders and record.get("visit_index") is not None:
+                            visit_number = int(record["visit_index"])
+                            visit = visits[visit_number] if visit_number < len(visits) else {}
+                            visit_name = _display(visit, f"Visit {visit_number + 1}")
+                            file_dir = file_dir / f"ses-{_bids_label(visit_name, f'{visit_number + 1:02d}') }"
+                    modalities = record.get("modalities") or []
+                    if isinstance(modalities, str):
+                        modalities = [modalities]
+                    modality = _slug(modalities[0] if modalities else "misc", "misc")
+                    file_dir = file_dir / modality
                     filename = _safe_export_filename(record.get("file_name"), f"file-{record.get('id')}")
-                    target = root / "sourcedata" / scope / f"file-{record.get('id')}_{filename}"
+                    target = file_dir / f"file-{record.get('id')}_{filename}"
                     target.parent.mkdir(parents=True, exist_ok=True)
                     shutil.copy2(source, target)
                     item["export_path"] = str(target.relative_to(root))

--- a/eCRF_frontend/src/components/StudyDataEntryComponent.vue
+++ b/eCRF_frontend/src/components/StudyDataEntryComponent.vue
@@ -4921,7 +4921,7 @@ applyImportedRowFromDialog(payload) {
           file_name: file.file_name || uploadedFileName(file),
         };
 
-        slotData[mIdx][fIdx] = field.constraints?.allowMultipleFiles
+        slotData[mIdx][fIdx] = field.constraints?.allowMultipleFiles !== false
           ? [...currentFiles, mergedFile]
           : mergedFile;
       });
@@ -5352,7 +5352,7 @@ applyImportedRowFromDialog(payload) {
         const sizeNum = Number(c.maxSizeMB);
         if (Number.isFinite(sizeNum) && sizeNum > 0)
           parts.push(`Max size: ${sizeNum} MB`);
-        if (c.allowMultipleFiles)
+        if (c.allowMultipleFiles !== false)
           parts.push("Multiple files: allowed");
         if (Array.isArray(c.modalities) && c.modalities.length)
           parts.push(`Modalities: ${c.modalities.join(", ")}`);
@@ -5682,7 +5682,7 @@ applyImportedRowFromDialog(payload) {
       const t = String(f?.type || "").toLowerCase();
       const allowMulti = !!c.allowMultiple;
       if (t === "slider") return null;
-      if (t === "file") return c.allowMultipleFiles ? [] : null;
+      if (t === "file") return c.allowMultipleFiles !== false ? [] : null;
       if (t === "table") {
       if (
           !ignoreDefaults &&
@@ -6446,7 +6446,7 @@ applyImportedRowFromDialog(payload) {
       const cons = def.constraints || {};
       const label = def.label || def.name || "This field";
       const val = this.entryData[s][v][g][mIdx][fIdx];
-      const allowMultiFiles = !!cons.allowMultipleFiles;
+      const allowMultiFiles = cons.allowMultipleFiles !== false;
       let isSkipped = !!(
         this.skipFlags[s]?.[v]?.[g]?.[mIdx]?.[fIdx]
       );
@@ -6736,7 +6736,7 @@ applyImportedRowFromDialog(payload) {
                 ? typeof val !== "boolean"
                 : val !== true
               : f.type === "file"
-              ? c.allowMultipleFiles
+              ? c.allowMultipleFiles !== false
                 ? !(Array.isArray(val) && val.length > 0)
                 : !val || (val.source === "url" ? !(val.url && String(val.url).trim()) : !(val.name && Number.isFinite(Number(val.size))))
               : Array.isArray(val)
@@ -6772,7 +6772,10 @@ applyImportedRowFromDialog(payload) {
 
           const key = this.errorKey(mIdx, fIdx);
           const cons = def.constraints || {};
-          const allowMulti = !!cons.allowMultipleFiles;
+          // FieldFileUpload defaults to multiple files unless explicitly disabled.
+          // Keep persistence semantics identical or filename metadata is saved while
+          // the corresponding File objects are silently skipped.
+          const allowMulti = cons.allowMultipleFiles !== false;
           const val = this.entryData[s][v][g][mIdx][fIdx];
           if (!val && !allowMulti) continue;
 
@@ -6800,7 +6803,9 @@ applyImportedRowFromDialog(payload) {
 
               if (it.source === "local") {
                 const file = matchFile(it);
-                if (!file) continue;
+                if (!file) {
+                  throw new Error(`Selected file ${it.name || "(unnamed)"} is no longer available for upload.`);
+                }
                 const fd = new FormData();
                 fd.append("uploaded_file", file);
                 fd.append("description", def.label || def.name || "");
@@ -6859,8 +6864,11 @@ applyImportedRowFromDialog(payload) {
           } else {
             if (!val) continue;
 
-            if (val.source === "local" && pendingArr[0] instanceof File) {
-              const file = pendingArr[0];
+            if (val.source === "local" && !val.dbId) {
+              const file = matchFile(val);
+              if (!(file instanceof File)) {
+                throw new Error(`Selected file ${val.name || "(unnamed)"} is no longer available for upload.`);
+              }
               const fd = new FormData();
               fd.append("uploaded_file", file);
               fd.append("description", def.label || def.name || "");
@@ -6892,7 +6900,7 @@ applyImportedRowFromDialog(payload) {
               delete this.pendingFiles[key];
             }
 
-            if (val.source === "url" && val.url) {
+            if (val.source === "url" && val.url && !val.dbId) {
               const fd = new FormData();
               fd.append("url", val.url);
               fd.append("description", def.label || def.name || "");

--- a/eCRF_frontend/src/components/StudyDownloadDialog.vue
+++ b/eCRF_frontend/src/components/StudyDownloadDialog.vue
@@ -39,7 +39,13 @@
             <span><i class="fas fa-check"></i> Participants table</span>
             <span><i class="fas fa-check"></i> Human-labelled eCRF data</span>
             <span><i class="fas fa-check"></i> Latest study template</span>
+            <span><i class="fas fa-check"></i> Subject and study-level files</span>
           </div>
+          <label class="subject-folder-option">
+            <input v-model="includeSubjectFolders" type="checkbox" />
+            <i class="fas fa-folder-open"></i>
+            <span><strong>Individual subject folders</strong><small>Place each subject's visit data in its own folder, with uploaded files grouped under modality folders.</small></span>
+          </label>
           <p>UUID field keys are replaced by their actual field names in analysis tables. The original template remains in <code>code/</code> for reproducibility.</p>
         </div>
 
@@ -87,6 +93,7 @@
               <label :class="{ disabled: scope === 'audit' }"><input v-model="includeTemplate" type="checkbox" :disabled="scope === 'audit'" /><i class="fas fa-file-code"></i><span><strong>Study template</strong><small>Versioned schema for reproducibility</small></span></label>
               <label :class="{ disabled: scope === 'audit' }"><input v-model="includeFiles" type="checkbox" :disabled="scope === 'audit'" /><i class="fas fa-paperclip"></i><span><strong>Uploaded files</strong><small>Subject and study-level files</small></span></label>
               <label><input v-model="includeAudit" type="checkbox" :disabled="scope === 'audit'" /><i class="fas fa-history"></i><span><strong>Audit log</strong><small>Study and subject change history</small></span></label>
+              <label :class="{ disabled: scope === 'audit' }"><input v-model="includeSubjectFolders" type="checkbox" :disabled="scope === 'audit'" /><i class="fas fa-folder-open"></i><span><strong>Individual subject folders</strong><small>Visit data and files grouped per subject</small></span></label>
             </div>
             <label v-if="includeFiles && scope !== 'audit'" class="field-row">
               <span>Files to include</span>
@@ -130,7 +137,7 @@ export default {
     return {
       mode: "bids", versionMode: "latest", specificVersion: null, scope: "whole",
       selectedSubjects: [], selectedGroups: [], selectedVisits: [],
-      includeData: true, includeTemplate: true, includeFiles: false, includeAudit: false, fileScope: "all",
+      includeData: true, includeTemplate: true, includeFiles: true, includeAudit: false, includeSubjectFolders: true, fileScope: "all",
       scopes: [
         { value: "whole", icon: "fas fa-th-large", label: "Whole study", help: "All subjects and visits" },
         { value: "subjects", icon: "fas fa-user", label: "Subject-wise", help: "Selected subjects" },
@@ -169,7 +176,7 @@ export default {
     submit() {
       if (this.invalidSelection) return;
       if (this.mode === "bids") {
-        this.$emit("download", { versions: "latest", include_data: true, include_template: true, include_files: false, include_audit: false });
+        this.$emit("download", { versions: "latest", include_data: true, include_template: true, include_files: true, file_scope: "all", include_audit: false, include_subject_folders: this.includeSubjectFolders });
         return;
       }
       const payload = {
@@ -180,6 +187,7 @@ export default {
         file_scope: this.fileScope,
         include_audit: this.scope === "audit" ? true : this.includeAudit,
         audit_only: this.scope === "audit",
+        include_subject_folders: this.scope === "audit" ? false : this.includeSubjectFolders,
       };
       if (this.scope === "subjects") payload.subject_indexes = this.selectedSubjects.join(",");
       if (this.scope === "groups") payload.group_indexes = this.selectedGroups.join(",");
@@ -203,6 +211,7 @@ export default {
 .mode-copy { display: flex; flex-direction: column; min-width: 0; }.mode-title { font-size: 15px; font-weight: 700; }.mode-description { margin-top: 5px; color: #4b5563; font-size: 12px; line-height: 1.45; }.mode-meta { margin-top: auto; padding-top: 8px; color: #6b7280; font-size: 11px; font-weight: 600; }
 .default-pill { position: absolute; top: -9px; right: 11px; padding: 3px 8px; border-radius: 999px; background: #111827; color: #fff; font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: .04em; }
 .package-preview { margin-top: 14px; padding: 14px; border: 1px solid #e0e0e0; border-radius: 10px; background: #fafafa; font-size: 13px; }.preview-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 8px 18px; margin-top: 10px; color: #374151; }.preview-grid i { width: 15px; color: #111827; font-size: 10px; }.package-preview p { margin: 12px 0 0; color: #6b7280; font-size: 12px; line-height: 1.5; }
+.subject-folder-option { display: grid; grid-template-columns: auto 24px 1fr; gap: 8px; align-items: center; margin-top: 12px; padding: 10px; border: 1px solid #d1d5db; border-radius: 8px; background: #fff; cursor: pointer; }.subject-folder-option > i { color: #4b5563; text-align: center; }.subject-folder-option strong, .subject-folder-option small { display: block; }.subject-folder-option small { margin-top: 3px; color: #6b7280; font-size: 11px; line-height: 1.4; }
 .form-section { padding: 18px 0; border-bottom: 1px solid #e5e7eb; }.form-section:last-child { border-bottom: 0; }.section-heading { display: flex; gap: 10px; align-items: flex-start; margin-bottom: 12px; }.section-heading > span { display: grid; place-items: center; flex: 0 0 24px; height: 24px; border-radius: 50%; background: #111827; color: #fff; font-size: 11px; font-weight: 700; }.section-heading h4 { margin: 0; font-size: 14px; font-weight: 700; }.section-heading small { display: block; margin-top: 2px; color: #6b7280; font-size: 11px; }.section-content { margin-left: 34px; }
 .scope-options strong, .scope-options small, .checkbox-options strong, .checkbox-options small { display: block; }.scope-options small, .checkbox-options small { margin-top: 3px; color: #6b7280; font-size: 11px; }
 .inline-options { display: flex; flex-wrap: wrap; gap: 9px; align-items: center; font-size: 13px; }.inline-options > label { padding: 8px 10px; border: 1px solid #e0e0e0; border-radius: 8px; background: #fff; }

--- a/eCRF_frontend/src/components/StudyDownloadDialog.vue
+++ b/eCRF_frontend/src/components/StudyDownloadDialog.vue
@@ -1,0 +1,214 @@
+<template>
+  <div v-if="open" class="dialog-overlay" @click.self="$emit('close')">
+    <div class="dialog dialog-export" role="dialog" aria-modal="true" aria-labelledby="study-download-title">
+      <div class="dialog-header">
+        <div>
+          <h3 id="study-download-title">Download study</h3>
+          <p class="dialog-subtitle">Download the standard BIDS package or choose custom export options.</p>
+        </div>
+        <button class="btn-minimal icon-only" type="button" aria-label="Close" @click="$emit('close')">×</button>
+      </div>
+
+      <div class="dialog-body">
+        <div class="mode-grid">
+          <label class="mode-card" :class="{ selected: mode === 'bids' }">
+            <input v-model="mode" type="radio" value="bids" />
+            <span class="mode-icon"><i class="fas fa-database"></i></span>
+            <span class="mode-copy">
+              <span class="mode-title">BIDS-compliant study</span>
+              <span class="mode-description">Analysis-ready data with human-readable field names in a fully structured BIDS package.</span>
+              <span class="mode-meta">Latest version · all subjects · template included</span>
+            </span>
+            <span class="default-pill">Default</span>
+          </label>
+          <label class="mode-card" :class="{ selected: mode === 'custom' }">
+            <input v-model="mode" type="radio" value="custom" />
+            <span class="mode-icon secondary"><i class="fas fa-sliders-h"></i></span>
+            <span class="mode-copy">
+              <span class="mode-title">Custom export</span>
+              <span class="mode-description">Choose versions, subjects, groups, visits, files, templates, and audit history.</span>
+              <span class="mode-meta">Focused scope · optional files and audit log</span>
+            </span>
+          </label>
+        </div>
+
+        <div v-if="mode === 'bids'" class="package-preview">
+          <strong>Included in this package</strong>
+          <div class="preview-grid">
+            <span><i class="fas fa-check"></i> Dataset metadata</span>
+            <span><i class="fas fa-check"></i> Participants table</span>
+            <span><i class="fas fa-check"></i> Human-labelled eCRF data</span>
+            <span><i class="fas fa-check"></i> Latest study template</span>
+          </div>
+          <p>UUID field keys are replaced by their actual field names in analysis tables. The original template remains in <code>code/</code> for reproducibility.</p>
+        </div>
+
+        <template v-else>
+          <div class="form-section">
+            <div class="section-heading"><span>1</span><div><h4>Study version</h4><small>Select the data and template version to export.</small></div></div>
+            <div class="inline-options section-content">
+              <label><input v-model="versionMode" type="radio" value="latest" /> Latest (v{{ latestVersion }})</label>
+              <label><input v-model="versionMode" type="radio" value="all" /> All versions</label>
+              <label><input v-model="versionMode" type="radio" value="specific" /> Specific version</label>
+              <select v-if="versionMode === 'specific'" v-model.number="specificVersion" class="form-select">
+                <option v-for="version in normalizedVersions" :key="version" :value="version">Version {{ version }}</option>
+              </select>
+            </div>
+          </div>
+
+          <div class="form-section">
+            <div class="section-heading"><span>2</span><div><h4>Export scope</h4><small>Download the entire study or a focused subset.</small></div></div>
+            <div class="scope-options section-content">
+              <label v-for="item in scopes" :key="item.value" :class="{ selected: scope === item.value }">
+                <input v-model="scope" type="radio" :value="item.value" />
+                <i :class="item.icon"></i>
+                <span><strong>{{ item.label }}</strong><small>{{ item.help }}</small></span>
+              </label>
+            </div>
+
+            <div v-if="scope === 'subjects'" class="selection-box">
+              <div class="selection-head"><strong>Select subjects</strong><button class="text-button" type="button" @click="toggleAll('subjects')">{{ selectedSubjects.length === subjects.length ? 'Clear all' : 'Select all' }}</button></div>
+              <div class="selection-grid"><label v-for="(subject, index) in subjects" :key="index"><input v-model="selectedSubjects" type="checkbox" :value="index" /> {{ subject.id || `Subject ${index + 1}` }}</label></div>
+            </div>
+            <div v-if="scope === 'groups'" class="selection-box">
+              <div class="selection-head"><strong>Select groups</strong><button class="text-button" type="button" @click="toggleAll('groups')">{{ selectedGroups.length === groups.length ? 'Clear all' : 'Select all' }}</button></div>
+              <div class="selection-grid"><label v-for="(group, index) in groups" :key="index"><input v-model="selectedGroups" type="checkbox" :value="index" /> {{ group.name || group.label || `Group ${index + 1}` }}</label></div>
+            </div>
+            <div v-if="scope === 'visits'" class="selection-box">
+              <div class="selection-head"><strong>Select visits</strong><button class="text-button" type="button" @click="toggleAll('visits')">{{ selectedVisits.length === visits.length ? 'Clear all' : 'Select all' }}</button></div>
+              <div class="selection-grid"><label v-for="(visit, index) in visits" :key="index"><input v-model="selectedVisits" type="checkbox" :value="index" /> {{ visit.name || visit.label || `Visit ${index + 1}` }}</label></div>
+            </div>
+          </div>
+
+          <div class="form-section">
+            <div class="section-heading"><span>3</span><div><h4>Package contents</h4><small>Choose what the downloaded ZIP should contain.</small></div></div>
+            <div class="checkbox-options section-content">
+              <label :class="{ disabled: scope === 'audit' }"><input v-model="includeData" type="checkbox" :disabled="scope === 'audit'" /><i class="fas fa-table"></i><span><strong>Analysis data</strong><small>Human-labelled phenotype TSV files</small></span></label>
+              <label :class="{ disabled: scope === 'audit' }"><input v-model="includeTemplate" type="checkbox" :disabled="scope === 'audit'" /><i class="fas fa-file-code"></i><span><strong>Study template</strong><small>Versioned schema for reproducibility</small></span></label>
+              <label :class="{ disabled: scope === 'audit' }"><input v-model="includeFiles" type="checkbox" :disabled="scope === 'audit'" /><i class="fas fa-paperclip"></i><span><strong>Uploaded files</strong><small>Subject and study-level files</small></span></label>
+              <label><input v-model="includeAudit" type="checkbox" :disabled="scope === 'audit'" /><i class="fas fa-history"></i><span><strong>Audit log</strong><small>Study and subject change history</small></span></label>
+            </div>
+            <label v-if="includeFiles && scope !== 'audit'" class="field-row">
+              <span>Files to include</span>
+              <select v-model="fileScope" class="form-select">
+                <option value="all">Subject and study-level files</option>
+                <option value="subject">Subject files only</option>
+                <option value="study">Study-level files only</option>
+              </select>
+            </label>
+          </div>
+        </template>
+      </div>
+
+      <div class="dialog-actions">
+        <div class="download-summary">
+          <strong>{{ summaryTitle }}</strong>
+          <small>{{ summaryText }}</small>
+        </div>
+        <button class="btn-minimal" type="button" :disabled="downloading" @click="$emit('close')">Cancel</button>
+        <button class="btn-primary" type="button" :disabled="downloading || invalidSelection" @click="submit">
+          {{ downloading ? 'Preparing ZIP…' : 'Download ZIP' }}
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "StudyDownloadDialog",
+  props: {
+    open: { type: Boolean, default: false },
+    downloading: { type: Boolean, default: false },
+    subjects: { type: Array, default: () => [] },
+    groups: { type: Array, default: () => [] },
+    visits: { type: Array, default: () => [] },
+    versions: { type: Array, default: () => [] },
+  },
+  emits: ["close", "download"],
+  data() {
+    return {
+      mode: "bids", versionMode: "latest", specificVersion: null, scope: "whole",
+      selectedSubjects: [], selectedGroups: [], selectedVisits: [],
+      includeData: true, includeTemplate: true, includeFiles: false, includeAudit: false, fileScope: "all",
+      scopes: [
+        { value: "whole", icon: "fas fa-th-large", label: "Whole study", help: "All subjects and visits" },
+        { value: "subjects", icon: "fas fa-user", label: "Subject-wise", help: "Selected subjects" },
+        { value: "groups", icon: "fas fa-users", label: "Group-wise", help: "Selected groups" },
+        { value: "visits", icon: "fas fa-calendar-alt", label: "Visit-wise", help: "Selected visits" },
+        { value: "files", icon: "fas fa-folder-open", label: "Files only", help: "Uploaded files" },
+        { value: "audit", icon: "fas fa-history", label: "Audit log only", help: "Change history" },
+      ],
+    };
+  },
+  computed: {
+    normalizedVersions() { return (this.versions || []).map(v => Number(v.version ?? v)).filter(Number.isFinite).sort((a, b) => a - b); },
+    latestVersion() { return this.normalizedVersions[this.normalizedVersions.length - 1] || 1; },
+    invalidSelection() {
+      return this.mode === "custom" && ((this.scope === "subjects" && !this.selectedSubjects.length) || (this.scope === "groups" && !this.selectedGroups.length) || (this.scope === "visits" && !this.selectedVisits.length));
+    },
+    summaryTitle() { return this.mode === "bids" ? "BIDS-compliant whole study" : this.scopes.find(item => item.value === this.scope)?.label || "Custom export"; },
+    summaryText() {
+      if (this.mode === "bids") return `Latest version (v${this.latestVersion}), ${this.subjects.length} subject${this.subjects.length === 1 ? "" : "s"}`;
+      return this.versionMode === "all" ? "All study versions" : this.versionMode === "specific" ? `Study version ${this.specificVersion}` : `Latest version (v${this.latestVersion})`;
+    },
+  },
+  watch: {
+    open(value) { if (value && !this.specificVersion) this.specificVersion = this.latestVersion; },
+    scope(value) {
+      if (value === "audit") { this.includeAudit = true; this.includeData = false; this.includeTemplate = false; this.includeFiles = false; }
+      if (value === "files") { this.includeFiles = true; this.includeData = false; this.includeTemplate = false; this.includeAudit = false; }
+    },
+  },
+  methods: {
+    toggleAll(kind) {
+      const map = { subjects: ["selectedSubjects", this.subjects], groups: ["selectedGroups", this.groups], visits: ["selectedVisits", this.visits] };
+      const [key, items] = map[kind];
+      this[key] = this[key].length === items.length ? [] : items.map((_, index) => index);
+    },
+    submit() {
+      if (this.invalidSelection) return;
+      if (this.mode === "bids") {
+        this.$emit("download", { versions: "latest", include_data: true, include_template: true, include_files: false, include_audit: false });
+        return;
+      }
+      const payload = {
+        versions: this.versionMode === "specific" ? String(this.specificVersion) : this.versionMode,
+        include_data: this.scope === "audit" ? false : this.includeData,
+        include_template: this.scope === "audit" ? false : this.includeTemplate,
+        include_files: this.scope === "audit" ? false : this.includeFiles,
+        file_scope: this.fileScope,
+        include_audit: this.scope === "audit" ? true : this.includeAudit,
+        audit_only: this.scope === "audit",
+      };
+      if (this.scope === "subjects") payload.subject_indexes = this.selectedSubjects.join(",");
+      if (this.scope === "groups") payload.group_indexes = this.selectedGroups.join(",");
+      if (this.scope === "visits") payload.visit_indexes = this.selectedVisits.join(",");
+      this.$emit("download", payload);
+    },
+  },
+};
+</script>
+
+<style scoped>
+.dialog-overlay { position: fixed; inset: 0; z-index: 1000; display: flex; align-items: center; justify-content: center; padding: 20px; background: rgba(0, 0, 0, .35); }
+.dialog { width: 100%; max-width: 860px; max-height: 88vh; display: flex; flex-direction: column; padding: 16px; overflow: hidden; border-radius: 12px; background: #fff; box-shadow: 0 10px 30px rgba(0, 0, 0, .15); color: #111827; }
+.dialog-header { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; padding: 2px 2px 14px; border-bottom: 1px solid #e5e7eb; }
+.dialog h3 { margin: 0; font-size: 18px; font-weight: 700; }.dialog-subtitle { margin: 5px 0 0; color: #6b7280; font-size: 13px; }
+.dialog-body { overflow-y: auto; padding: 18px 4px 0 2px; }
+.mode-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+.mode-card { position: relative; display: flex; gap: 13px; min-height: 128px; padding: 16px; border: 1px solid #e0e0e0; border-radius: 10px; background: #fff; cursor: pointer; transition: border-color .2s, background .2s, box-shadow .2s, transform .05s; }
+.mode-card:hover { border-color: #b8bcc3; background: #fcfcfc; }.mode-card.selected { border-color: #111827; background: #f9fafb; box-shadow: 0 0 0 2px rgba(17, 24, 39, .06); }.mode-card > input { position: absolute; opacity: 0; pointer-events: none; }
+.mode-icon { flex: 0 0 auto; display: grid; place-items: center; width: 42px; height: 42px; border-radius: 9px; background: #111827; color: #fff; font-size: 16px; }.mode-icon.secondary { border: 1px solid #e0e0e0; background: #f3f4f6; color: #374151; }
+.mode-copy { display: flex; flex-direction: column; min-width: 0; }.mode-title { font-size: 15px; font-weight: 700; }.mode-description { margin-top: 5px; color: #4b5563; font-size: 12px; line-height: 1.45; }.mode-meta { margin-top: auto; padding-top: 8px; color: #6b7280; font-size: 11px; font-weight: 600; }
+.default-pill { position: absolute; top: -9px; right: 11px; padding: 3px 8px; border-radius: 999px; background: #111827; color: #fff; font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: .04em; }
+.package-preview { margin-top: 14px; padding: 14px; border: 1px solid #e0e0e0; border-radius: 10px; background: #fafafa; font-size: 13px; }.preview-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 8px 18px; margin-top: 10px; color: #374151; }.preview-grid i { width: 15px; color: #111827; font-size: 10px; }.package-preview p { margin: 12px 0 0; color: #6b7280; font-size: 12px; line-height: 1.5; }
+.form-section { padding: 18px 0; border-bottom: 1px solid #e5e7eb; }.form-section:last-child { border-bottom: 0; }.section-heading { display: flex; gap: 10px; align-items: flex-start; margin-bottom: 12px; }.section-heading > span { display: grid; place-items: center; flex: 0 0 24px; height: 24px; border-radius: 50%; background: #111827; color: #fff; font-size: 11px; font-weight: 700; }.section-heading h4 { margin: 0; font-size: 14px; font-weight: 700; }.section-heading small { display: block; margin-top: 2px; color: #6b7280; font-size: 11px; }.section-content { margin-left: 34px; }
+.scope-options strong, .scope-options small, .checkbox-options strong, .checkbox-options small { display: block; }.scope-options small, .checkbox-options small { margin-top: 3px; color: #6b7280; font-size: 11px; }
+.inline-options { display: flex; flex-wrap: wrap; gap: 9px; align-items: center; font-size: 13px; }.inline-options > label { padding: 8px 10px; border: 1px solid #e0e0e0; border-radius: 8px; background: #fff; }
+.scope-options { display: grid; grid-template-columns: repeat(3, 1fr); gap: 8px; }.scope-options > label { display: grid; grid-template-columns: auto 25px 1fr; gap: 7px; align-items: center; min-height: 54px; padding: 9px; border: 1px solid #e0e0e0; border-radius: 8px; cursor: pointer; }.scope-options > label.selected { border-color: #111827; background: #f9fafb; box-shadow: 0 0 0 1px rgba(17, 24, 39, .05); }.scope-options > label > i { color: #4b5563; font-size: 15px; text-align: center; }
+.form-select { min-height: 36px; padding: 7px 10px; border: 1px solid #d1d5db; border-radius: 8px; background: #fff; color: #111827; font-size: 13px; }.selection-box { margin: 10px 0 0 34px; padding: 12px; max-height: 170px; overflow: auto; border: 1px solid #e0e0e0; border-radius: 8px; background: #fafafa; }.selection-head { display: flex; justify-content: space-between; margin-bottom: 10px; font-size: 13px; }.selection-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 8px; font-size: 13px; }.text-button { padding: 0; border: 0; background: none; color: #374151; text-decoration: underline; cursor: pointer; }.disabled { opacity: .5; }
+.checkbox-options { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; font-size: 13px; }.checkbox-options > label { display: grid; grid-template-columns: auto 26px 1fr; gap: 8px; align-items: center; padding: 10px; border: 1px solid #e0e0e0; border-radius: 8px; background: #fff; cursor: pointer; }.checkbox-options > label > i { color: #4b5563; font-size: 14px; text-align: center; }.field-row { display: flex; align-items: center; gap: 12px; margin: 12px 0 0 34px; color: #4b5563; font-size: 13px; }
+.dialog-actions { display: flex; align-items: center; justify-content: flex-end; gap: 8px; padding-top: 14px; border-top: 1px solid #e5e7eb; }.download-summary { display: flex; flex: 1; flex-direction: column; gap: 2px; font-size: 12px; }.download-summary small { color: #6b7280; }.btn-primary { padding: 10px 12px; border: 1px solid transparent; border-radius: 10px; background: #111827; color: #fff; font-size: 14px; cursor: pointer; }.btn-primary[disabled] { opacity: .6; cursor: not-allowed; }.btn-minimal { padding: 8px 12px; border: 1px solid #e0e0e0; border-radius: 8px; background: none; color: #555; font-size: 14px; cursor: pointer; }.btn-minimal:hover:not([disabled]) { background: #e8e8e8; color: #000; }.btn-minimal.icon-only { padding: 5px 10px; font-size: 20px; line-height: 1; }input { accent-color: #111827; }
+@media (max-width: 700px) { .mode-grid, .checkbox-options { grid-template-columns: 1fr; }.scope-options, .selection-grid { grid-template-columns: 1fr 1fr; }.download-summary { display: none; }.section-content, .selection-box, .field-row { margin-left: 0; } }
+</style>

--- a/eCRF_frontend/src/components/StudyDownloadDialog.vue
+++ b/eCRF_frontend/src/components/StudyDownloadDialog.vue
@@ -17,7 +17,7 @@
             <span class="mode-copy">
               <span class="mode-title">BIDS-compliant study</span>
               <span class="mode-description">Analysis-ready data with human-readable field names in a fully structured BIDS package.</span>
-              <span class="mode-meta">Latest version · all subjects · template included</span>
+              <span class="mode-meta">{{ versionMode === 'all' ? 'All versions combined' : 'Latest version' }} · all subjects · template included</span>
             </span>
             <span class="default-pill">Default</span>
           </label>
@@ -38,8 +38,25 @@
             <span><i class="fas fa-check"></i> Dataset metadata</span>
             <span><i class="fas fa-check"></i> Participants table</span>
             <span><i class="fas fa-check"></i> Human-labelled eCRF data</span>
-            <span><i class="fas fa-check"></i> Latest study template</span>
+            <span><i class="fas fa-check"></i> {{ versionMode === 'all' ? 'All study templates' : 'Latest study template' }}</span>
             <span><i class="fas fa-check"></i> Subject and study-level files</span>
+          </div>
+          <div class="bids-version-choice">
+            <strong>Data version</strong>
+            <div class="inline-options">
+              <label><input v-model="versionMode" type="radio" value="latest" /> Latest (v{{ latestVersion }})</label>
+              <label :class="{ disabled: normalizedVersions.length < 2 }"><input v-model="versionMode" type="radio" value="all" :disabled="normalizedVersions.length < 2" /> Combine all versions</label>
+            </div>
+          </div>
+          <div v-if="versionMode === 'all'" class="combined-version-info">
+            <div class="combined-title"><i class="fas fa-columns"></i><span><strong>One row per participant and visit</strong><small>All versions are placed side by side in one <code>phenotype/ecrf.tsv</code>.</small></span></div>
+            <code class="column-example">age&nbsp;&nbsp; notes__v001&nbsp;&nbsp; notes__v002&nbsp;&nbsp; medication__row01__dose</code>
+            <ul>
+              <li>Unchanged fields appear once and use their latest available value.</li>
+              <li>Only added, removed, renamed, or structurally changed fields receive version columns.</li>
+              <li>Changed repeating tables become version snapshots; historical rows are not matched automatically.</li>
+            </ul>
+            <div class="estimate-strip"><span>{{ normalizedVersions.length }} versions</span><span>Up to {{ combinedRowEstimate }} participant/visit rows</span><span>Columns calculated during export</span></div>
           </div>
           <label class="subject-folder-option">
             <input v-model="includeSubjectFolders" type="checkbox" />
@@ -54,11 +71,21 @@
             <div class="section-heading"><span>1</span><div><h4>Study version</h4><small>Select the data and template version to export.</small></div></div>
             <div class="inline-options section-content">
               <label><input v-model="versionMode" type="radio" value="latest" /> Latest (v{{ latestVersion }})</label>
-              <label><input v-model="versionMode" type="radio" value="all" /> All versions</label>
+              <label :class="{ disabled: normalizedVersions.length < 2 }"><input v-model="versionMode" type="radio" value="all" :disabled="normalizedVersions.length < 2" /> Combine all versions</label>
               <label><input v-model="versionMode" type="radio" value="specific" /> Specific version</label>
               <select v-if="versionMode === 'specific'" v-model.number="specificVersion" class="form-select">
                 <option v-for="version in normalizedVersions" :key="version" :value="version">Version {{ version }}</option>
               </select>
+            </div>
+            <div v-if="versionMode === 'all' && includeData && scope !== 'audit'" class="combined-version-info section-content">
+              <div class="combined-title"><i class="fas fa-columns"></i><span><strong>One row per participant and visit</strong><small>All versions are placed side by side in one <code>phenotype/ecrf.tsv</code>.</small></span></div>
+              <code class="column-example">age&nbsp;&nbsp; notes__v001&nbsp;&nbsp; notes__v002&nbsp;&nbsp; medication__row01__dose</code>
+              <ul>
+                <li>Unchanged fields appear once and use their latest available value.</li>
+                <li>Only added, removed, renamed, or structurally changed fields receive version columns.</li>
+                <li>Changed repeating tables become version snapshots; historical rows are not matched automatically.</li>
+              </ul>
+              <div class="estimate-strip"><span>{{ normalizedVersions.length }} versions</span><span>Up to {{ combinedRowEstimate }} participant/visit rows</span><span>Columns calculated during export</span></div>
             </div>
           </div>
 
@@ -151,17 +178,33 @@ export default {
   computed: {
     normalizedVersions() { return (this.versions || []).map(v => Number(v.version ?? v)).filter(Number.isFinite).sort((a, b) => a - b); },
     latestVersion() { return this.normalizedVersions[this.normalizedVersions.length - 1] || 1; },
+    combinedRowEstimate() {
+      let subjectCount = this.subjects.length;
+      let visitCount = this.visits.length;
+      if (this.mode === "custom" && this.scope === "subjects") subjectCount = this.selectedSubjects.length;
+      if (this.mode === "custom" && this.scope === "groups") {
+        const selectedNames = new Set(this.selectedGroups.map(index => String(this.groups[index]?.name || this.groups[index]?.label || "").trim().toLowerCase()));
+        subjectCount = this.subjects.filter(subject => selectedNames.has(String(subject?.group || "").trim().toLowerCase())).length;
+      }
+      if (this.mode === "custom" && this.scope === "visits") visitCount = this.selectedVisits.length;
+      return subjectCount * visitCount;
+    },
     invalidSelection() {
       return this.mode === "custom" && ((this.scope === "subjects" && !this.selectedSubjects.length) || (this.scope === "groups" && !this.selectedGroups.length) || (this.scope === "visits" && !this.selectedVisits.length));
     },
     summaryTitle() { return this.mode === "bids" ? "BIDS-compliant whole study" : this.scopes.find(item => item.value === this.scope)?.label || "Custom export"; },
     summaryText() {
-      if (this.mode === "bids") return `Latest version (v${this.latestVersion}), ${this.subjects.length} subject${this.subjects.length === 1 ? "" : "s"}`;
-      return this.versionMode === "all" ? "All study versions" : this.versionMode === "specific" ? `Study version ${this.specificVersion}` : `Latest version (v${this.latestVersion})`;
+      if (this.mode === "bids") return this.versionMode === "all" ? `${this.normalizedVersions.length} versions combined, ${this.subjects.length} subject${this.subjects.length === 1 ? "" : "s"}` : `Latest version (v${this.latestVersion}), ${this.subjects.length} subject${this.subjects.length === 1 ? "" : "s"}`;
+      return this.versionMode === "all" ? `${this.normalizedVersions.length} study versions combined` : this.versionMode === "specific" ? `Study version ${this.specificVersion}` : `Latest version (v${this.latestVersion})`;
     },
   },
   watch: {
-    open(value) { if (value && !this.specificVersion) this.specificVersion = this.latestVersion; },
+    open(value) {
+      if (!value) return;
+      if (!this.specificVersion) this.specificVersion = this.latestVersion;
+      if (this.normalizedVersions.length < 2 && this.versionMode === "all") this.versionMode = "latest";
+    },
+    mode(value) { if (value === "bids" && this.versionMode === "specific") this.versionMode = "latest"; },
     scope(value) {
       if (value === "audit") { this.includeAudit = true; this.includeData = false; this.includeTemplate = false; this.includeFiles = false; }
       if (value === "files") { this.includeFiles = true; this.includeData = false; this.includeTemplate = false; this.includeAudit = false; }
@@ -176,7 +219,7 @@ export default {
     submit() {
       if (this.invalidSelection) return;
       if (this.mode === "bids") {
-        this.$emit("download", { versions: "latest", include_data: true, include_template: true, include_files: true, file_scope: "all", include_audit: false, include_subject_folders: this.includeSubjectFolders });
+        this.$emit("download", { versions: this.versionMode === "all" ? "all" : "latest", include_data: true, include_template: true, include_files: true, file_scope: "all", include_audit: false, include_subject_folders: this.includeSubjectFolders });
         return;
       }
       const payload = {
@@ -211,6 +254,7 @@ export default {
 .mode-copy { display: flex; flex-direction: column; min-width: 0; }.mode-title { font-size: 15px; font-weight: 700; }.mode-description { margin-top: 5px; color: #4b5563; font-size: 12px; line-height: 1.45; }.mode-meta { margin-top: auto; padding-top: 8px; color: #6b7280; font-size: 11px; font-weight: 600; }
 .default-pill { position: absolute; top: -9px; right: 11px; padding: 3px 8px; border-radius: 999px; background: #111827; color: #fff; font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: .04em; }
 .package-preview { margin-top: 14px; padding: 14px; border: 1px solid #e0e0e0; border-radius: 10px; background: #fafafa; font-size: 13px; }.preview-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 8px 18px; margin-top: 10px; color: #374151; }.preview-grid i { width: 15px; color: #111827; font-size: 10px; }.package-preview p { margin: 12px 0 0; color: #6b7280; font-size: 12px; line-height: 1.5; }
+.bids-version-choice { margin-top: 14px; padding-top: 12px; border-top: 1px solid #e5e7eb; }.bids-version-choice > strong { display: block; margin-bottom: 8px; font-size: 12px; }.combined-version-info { margin-top: 10px; padding: 12px; border: 1px solid #d1d5db; border-radius: 9px; background: #fff; color: #374151; }.combined-title { display: flex; gap: 9px; align-items: flex-start; }.combined-title > i { width: 22px; padding-top: 2px; color: #111827; text-align: center; }.combined-title strong, .combined-title small { display: block; }.combined-title small { margin-top: 3px; color: #6b7280; font-size: 11px; line-height: 1.4; }.column-example { display: block; margin-top: 10px; padding: 8px; overflow-x: auto; border-radius: 6px; background: #f3f4f6; color: #374151; font-size: 10px; white-space: nowrap; }.combined-version-info ul { margin: 9px 0 0 18px; padding: 0; color: #4b5563; font-size: 11px; line-height: 1.55; }.estimate-strip { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 10px; }.estimate-strip span { padding: 4px 7px; border: 1px solid #e5e7eb; border-radius: 999px; background: #f9fafb; color: #4b5563; font-size: 10px; font-weight: 600; }
 .subject-folder-option { display: grid; grid-template-columns: auto 24px 1fr; gap: 8px; align-items: center; margin-top: 12px; padding: 10px; border: 1px solid #d1d5db; border-radius: 8px; background: #fff; cursor: pointer; }.subject-folder-option > i { color: #4b5563; text-align: center; }.subject-folder-option strong, .subject-folder-option small { display: block; }.subject-folder-option small { margin-top: 3px; color: #6b7280; font-size: 11px; line-height: 1.4; }
 .form-section { padding: 18px 0; border-bottom: 1px solid #e5e7eb; }.form-section:last-child { border-bottom: 0; }.section-heading { display: flex; gap: 10px; align-items: flex-start; margin-bottom: 12px; }.section-heading > span { display: grid; place-items: center; flex: 0 0 24px; height: 24px; border-radius: 50%; background: #111827; color: #fff; font-size: 11px; font-weight: 700; }.section-heading h4 { margin: 0; font-size: 14px; font-weight: 700; }.section-heading small { display: block; margin-top: 2px; color: #6b7280; font-size: 11px; }.section-content { margin-left: 34px; }
 .scope-options strong, .scope-options small, .checkbox-options strong, .checkbox-options small { display: block; }.scope-options small, .checkbox-options small { margin-top: 3px; color: #6b7280; font-size: 11px; }
@@ -219,5 +263,5 @@ export default {
 .form-select { min-height: 36px; padding: 7px 10px; border: 1px solid #d1d5db; border-radius: 8px; background: #fff; color: #111827; font-size: 13px; }.selection-box { margin: 10px 0 0 34px; padding: 12px; max-height: 170px; overflow: auto; border: 1px solid #e0e0e0; border-radius: 8px; background: #fafafa; }.selection-head { display: flex; justify-content: space-between; margin-bottom: 10px; font-size: 13px; }.selection-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 8px; font-size: 13px; }.text-button { padding: 0; border: 0; background: none; color: #374151; text-decoration: underline; cursor: pointer; }.disabled { opacity: .5; }
 .checkbox-options { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; font-size: 13px; }.checkbox-options > label { display: grid; grid-template-columns: auto 26px 1fr; gap: 8px; align-items: center; padding: 10px; border: 1px solid #e0e0e0; border-radius: 8px; background: #fff; cursor: pointer; }.checkbox-options > label > i { color: #4b5563; font-size: 14px; text-align: center; }.field-row { display: flex; align-items: center; gap: 12px; margin: 12px 0 0 34px; color: #4b5563; font-size: 13px; }
 .dialog-actions { display: flex; align-items: center; justify-content: flex-end; gap: 8px; padding-top: 14px; border-top: 1px solid #e5e7eb; }.download-summary { display: flex; flex: 1; flex-direction: column; gap: 2px; font-size: 12px; }.download-summary small { color: #6b7280; }.btn-primary { padding: 10px 12px; border: 1px solid transparent; border-radius: 10px; background: #111827; color: #fff; font-size: 14px; cursor: pointer; }.btn-primary[disabled] { opacity: .6; cursor: not-allowed; }.btn-minimal { padding: 8px 12px; border: 1px solid #e0e0e0; border-radius: 8px; background: none; color: #555; font-size: 14px; cursor: pointer; }.btn-minimal:hover:not([disabled]) { background: #e8e8e8; color: #000; }.btn-minimal.icon-only { padding: 5px 10px; font-size: 20px; line-height: 1; }input { accent-color: #111827; }
-@media (max-width: 700px) { .mode-grid, .checkbox-options { grid-template-columns: 1fr; }.scope-options, .selection-grid { grid-template-columns: 1fr 1fr; }.download-summary { display: none; }.section-content, .selection-box, .field-row { margin-left: 0; } }
+@media (max-width: 700px) { .mode-grid, .checkbox-options { grid-template-columns: 1fr; }.scope-options, .selection-grid { grid-template-columns: 1fr 1fr; }.download-summary { display: none; }.section-content, .selection-box, .field-row { margin-left: 0; }.estimate-strip { flex-direction: column; align-items: flex-start; } }
 </style>

--- a/eCRF_frontend/src/components/StudyView.vue
+++ b/eCRF_frontend/src/components/StudyView.vue
@@ -605,38 +605,35 @@
             <div class="subsection">
               <h3 class="sub-title">Study exports</h3>
               <p class="muted">
-                Export the study template or download a ZIP bundle of the study.
+                Prepare analysis-ready data, a focused study package, or a reusable template.
               </p>
 
-              <div class="bids-actions export-actions">
-                  <button class="btn-primary" type="button" @click="exportStudyTemplate">
-                    Export Study Template
+              <div class="study-export-grid">
+                <button v-if="canDownloadFullStudy" class="main-export-option" type="button" :disabled="downloadingFullStudyZip" @click="showDownloadDialog = true">
+                  <span class="export-option-icon"><i class="fas fa-download"></i></span>
+                  <span class="export-option-copy">
+                    <span class="export-option-label">RECOMMENDED</span>
+                    <strong>{{ downloadingFullStudyZip ? "Preparing…" : "Download Study" }}</strong>
+                    <small>BIDS-compliant study by default, with subject, group, visit, file, audit, and version controls.</small>
+                    <span class="export-option-action">Choose download options <i class="fas fa-arrow-right"></i></span>
+                  </span>
+                </button>
+                <div class="secondary-export-options">
+                  <button type="button" @click="exportStudyTemplate">
+                    <span class="secondary-export-icon"><i class="fas fa-file-export"></i></span>
+                    <span><strong>Export Study Template</strong><small>Reusable study structure without collected data</small></span>
+                    <i class="fas fa-chevron-right"></i>
                   </button>
-
-                  <!-- Only owner/admin -->
-                  <template v-if="canDownloadFullStudy">
-                    <button
-                      class="btn-primary"
-                      type="button"
-                      :disabled="downloadingMergeZip"
-                      @click="downloadStudyZip"
-                    >
-                      {{ downloadingMergeZip ? "Downloading…" : "Download Study For Merge" }}
-                    </button>
-
-                    <button
-                      class="btn-primary"
-                      type="button"
-                      :disabled="downloadingFullStudyZip"
-                      @click="downloadFullStudyZip"
-                    >
-                      {{ downloadingFullStudyZip ? "Downloading…" : "Download Study" }}
-                    </button>
-                  </template>
-                  <div v-else class="muted" style="margin-top: 10px;">
+                  <button v-if="canDownloadFullStudy" type="button" :disabled="downloadingMergeZip" @click="downloadStudyZip">
+                    <span class="secondary-export-icon"><i class="fas fa-exchange-alt"></i></span>
+                    <span><strong>{{ downloadingMergeZip ? "Preparing…" : "Download Study For Merge" }}</strong><small>Template and CSV bundle for importing elsewhere</small></span>
+                    <i class="fas fa-chevron-right"></i>
+                  </button>
+                </div>
+                <div v-if="!canDownloadFullStudy" class="muted export-permission-note">
                   Only the study owner or an administrator can download the full study.
                 </div>
-                </div>
+              </div>
             </div>
 
             <!-- Existing dataset (kept as-is) -->
@@ -717,6 +714,16 @@
         </div>
       </div>
     </div>
+    <StudyDownloadDialog
+      :open="showDownloadDialog"
+      :downloading="downloadingFullStudyZip"
+      :subjects="subjects"
+      :groups="groups"
+      :visits="visits"
+      :versions="versions"
+      @close="showDownloadDialog = false"
+      @download="downloadFullStudyZip"
+    />
   </div>
 </template>
 
@@ -730,10 +737,11 @@ import StudyComplianceView from "@/components/StudyComplianceView.vue";
 import icons from "@/assets/styles/icons";
 import { downloadStudyBundle } from "@/utils/studyDownload";
 import ExportStudy from "@/components/ExportStudy.vue";
+import StudyDownloadDialog from "@/components/StudyDownloadDialog.vue";
 
 export default {
   name: "StudyView",
-  components: { FieldFileUpload, StudyAuditLogs, TemplateDiffView, StudyDataDashboard, StudyComplianceView, ExportStudy },
+  components: { FieldFileUpload, StudyAuditLogs, TemplateDiffView, StudyDataDashboard, StudyComplianceView, ExportStudy, StudyDownloadDialog },
   data() {
     return {
       deleteConfirm: {
@@ -793,6 +801,7 @@ export default {
 
       // Export template embedding state (NO new tab, no route)
       showExportTemplate: false,
+      showDownloadDialog: false,
 
       //  7-step edit launcher (kept)
       editSteps: [
@@ -1029,7 +1038,7 @@ export default {
       }
     },
 
-    async downloadFullStudyZip() {
+    async downloadFullStudyZip(options = {}) {
       const token = this.token;
       if (!token) {
         alert("Please log in again.");
@@ -1040,10 +1049,11 @@ export default {
       this.downloadingFullStudyZip = true;
       try {
         const response = await axios.get(
-          `/forms/studies/${this.studyId}/download`,
+          `/forms/studies/${this.studyId}/export`,
           {
             headers: { Authorization: `Bearer ${token}` },
             responseType: "blob",
+            params: options,
           }
         );
 
@@ -1070,6 +1080,7 @@ export default {
         link.remove();
 
         window.URL.revokeObjectURL(url);
+        this.showDownloadDialog = false;
       } catch (e) {
         console.error("Failed to download full study:", e?.response?.data || e.message);
         alert("Failed to download full study.");
@@ -2210,6 +2221,12 @@ export default {
 .bids-actions.export-actions .btn-primary {
   margin: 0;
 }
+.study-export-grid { display: grid; grid-template-columns: minmax(320px, 1.1fr) minmax(300px, .9fr); gap: 12px; margin-top: 16px; }
+.main-export-option { display: flex; gap: 14px; min-height: 166px; padding: 18px; text-align: left; border: 1px solid #111827; border-radius: 12px; background: #f9fafb; color: #111827; cursor: pointer; transition: background .2s, box-shadow .2s, transform .05s; }
+.main-export-option:hover:not(:disabled) { background: #f3f4f6; box-shadow: 0 6px 18px rgba(0,0,0,.08); transform: translateY(-1px); }.main-export-option:disabled { opacity: .6; cursor: wait; }
+.export-option-icon { display: grid; place-items: center; flex: 0 0 44px; height: 44px; border-radius: 9px; background: #111827; color: #fff; font-size: 16px; }.export-option-copy { display: flex; flex-direction: column; align-items: flex-start; }.export-option-label { margin-bottom: 4px; color: #6b7280; font-size: 10px; font-weight: 700; letter-spacing: .08em; }.export-option-copy strong { font-size: 18px; }.export-option-copy small { margin-top: 6px; color: #4b5563; font-size: 12px; line-height: 1.5; }.export-option-action { margin-top: auto; padding-top: 12px; font-size: 12px; font-weight: 700; }.export-option-action i { margin-left: 5px; font-size: 10px; }
+.secondary-export-options { display: flex; flex-direction: column; gap: 10px; }.secondary-export-options button { display: grid; grid-template-columns: 38px 1fr auto; gap: 10px; align-items: center; min-height: 78px; padding: 12px; text-align: left; border: 1px solid #e0e0e0; border-radius: 10px; background: #fff; color: #111827; cursor: pointer; transition: background .2s, border-color .2s; }.secondary-export-options button:hover:not(:disabled) { border-color: #b8bcc3; background: #f9fafb; }.secondary-export-options button:disabled { opacity: .6; cursor: wait; }.secondary-export-options strong, .secondary-export-options small { display: block; }.secondary-export-options strong { font-size: 13px; }.secondary-export-options small { margin-top: 3px; color: #6b7280; font-size: 11px; line-height: 1.35; }.secondary-export-options > button > i { color: #9ca3af; font-size: 11px; }.secondary-export-icon { display: grid; place-items: center; width: 36px; height: 36px; border: 1px solid #e0e0e0; border-radius: 8px; background: #f3f4f6; color: #374151; }.export-permission-note { grid-column: 1 / -1; }
+@media (max-width: 820px) { .study-export-grid { grid-template-columns: 1fr; } }
 .edit-danger-zone {
   margin-top: 18px;
   display: flex;

--- a/tests/test_study_export.py
+++ b/tests/test_study_export.py
@@ -167,3 +167,187 @@ def test_individual_subject_folders_group_visit_data_and_modality_files(tmp_path
         assert subject_file in names
         assert "heart_rate" in bundle.read(subject_tsv).decode()
         assert bundle.read(subject_file).decode() == "scan payload"
+
+
+class MultiVersionRepo(FakeRepo):
+    def list_entries(self, study_id, study_name):
+        return [
+            {
+                "id": 11,
+                "subject_index": 0,
+                "visit_index": 0,
+                "group_index": 0,
+                "form_version": 1,
+                "updated_at": "2026-01-01T00:00:00Z",
+                "data": {
+                    "section-vitals": {
+                        "field-heart-rate": 72,
+                        "field-site-code": "Earlier value",
+                        "field-old-score": 8,
+                        "field-medications": {"rows": [
+                            {"table-drug": "Drug A", "table-dose": "5 mg"},
+                        ]},
+                    },
+                },
+            },
+            {
+                "id": 12,
+                "subject_index": 0,
+                "visit_index": 0,
+                "group_index": 0,
+                "form_version": 2,
+                "updated_at": "2026-02-01T00:00:00Z",
+                "data": {
+                    "section-vitals": {
+                        "field-heart-rate": 75,
+                        "field-site-code": "Latest value",
+                        "field-new-measure": 98,
+                        "field-medications": {"rows": [
+                            {"table-drug": "Drug A", "table-dose": "10 mg"},
+                            {"table-drug": "Drug B", "table-dose": "2 mg"},
+                        ]},
+                    },
+                },
+            },
+        ]
+
+
+def _versioned_schema(version):
+    fields = [{
+        "_id": "field-heart-rate",
+        "name": "heart_rate" if version == 1 else "pulse_rate",
+        "label": "Heart rate" if version == 1 else "Pulse rate",
+        "type": "number",
+    }, {
+        "_id": "field-site-code",
+        "name": "site_code",
+        "label": "Site code",
+        "type": "text",
+    }]
+    if version == 1:
+        fields.append({"_id": "field-old-score", "name": "old_score", "label": "Old score", "type": "number"})
+    else:
+        fields.append({"_id": "field-new-measure", "name": "new_measure", "label": "New measure", "type": "number"})
+    fields.append({
+        "_id": "field-medications",
+        "name": "medications",
+        "label": "Medications",
+        "type": "table",
+        "tableConfig": {"columns": [
+            {"id": "table-drug", "key": "drug", "label": "Drug", "type": "text"},
+            {"id": "table-dose", "key": "dose", "label": "Dose", "type": "text"},
+        ]},
+    })
+    return {
+        "subjects": [{"id": "SUBJ-A", "group": "Control"}],
+        "visits": [{"name": "Baseline"}],
+        "groups": [{"name": "Control"}],
+        "selectedModels": [{"_id": "section-vitals", "title": "Vitals", "fields": fields}],
+    }
+
+
+def test_all_versions_only_expand_fields_affected_by_form_changes(tmp_path):
+    repo = MultiVersionRepo(tmp_path)
+    schema_v1 = _versioned_schema(1)
+    schema_v2 = _versioned_schema(2)
+    archive, _ = build_analysis_export(
+        repo=repo,
+        study_id=4,
+        study_name="Heart Study",
+        study_data=schema_v2,
+        schemas_by_version={1: schema_v1, 2: schema_v2},
+        options=ExportOptions(versions={1, 2}, include_subject_folders=True),
+    )
+
+    with zipfile.ZipFile(archive) as bundle:
+        root = "study-4-heart-study_bids-export/"
+        names = set(bundle.namelist())
+        combined_tsv = root + "phenotype/ecrf.tsv"
+        combined_json = root + "phenotype/ecrf.json"
+        assert combined_tsv in names
+        assert combined_json in names
+        assert root + "phenotype/ecrf_version_001.tsv" not in names
+        assert root + "phenotype/ecrf_version_002.tsv" not in names
+
+        lines = bundle.read(combined_tsv).decode().splitlines()
+        assert len(lines) == 2
+        headers = lines[0].split("\t")
+        values = dict(zip(headers, lines[1].split("\t")))
+        assert headers[:3] == ["participant_id", "visit", "group"]
+        assert "study_version" not in headers
+        assert values["site_code"] == "Latest value"
+        assert "site_code__v001" not in headers
+        assert "site_code__v002" not in headers
+        assert values["pulse_rate__v001"] == "72"
+        assert values["pulse_rate__v002"] == "75"
+        assert values["old_score__v001"] == "8"
+        assert values["old_score__v002"] == "n/a"
+        assert values["new_measure__v001"] == "n/a"
+        assert values["new_measure__v002"] == "98"
+        assert values["medications__row01__dose"] == "10 mg"
+        assert values["medications__row02__drug"] == "Drug B"
+        assert values["medications__row02__dose"] == "2 mg"
+        assert not any(header.startswith("medications__v") for header in headers)
+
+        sidecar = json.loads(bundle.read(combined_json))
+        assert sidecar["new_measure__v001"]["FieldAvailableInVersion"] is False
+        assert sidecar["new_measure__v002"]["FieldAvailableInVersion"] is True
+        assert sidecar["MeasurementToolMetadata"]["VersionsIncluded"] == [1, 2]
+
+        subject_tsv = root + "sourcedata/sub-SUBJA/ses-Baseline/ecrf/sub-SUBJA_ses-Baseline_ecrf.tsv"
+        assert subject_tsv in names
+        assert bundle.read(subject_tsv).decode() == bundle.read(combined_tsv).decode()
+
+
+def test_only_removed_notes_gets_version_columns_when_everything_else_is_unchanged(tmp_path):
+    class NotesRemovedRepo(FakeRepo):
+        def list_entries(self, study_id, study_name):
+            return [{
+                "id": 21,
+                "subject_index": 0,
+                "visit_index": 0,
+                "group_index": 0,
+                "form_version": 1,
+                "updated_at": "2026-01-01T00:00:00Z",
+                "data": {"section": {"temperature": 36.5, "notes": "Initial note"}},
+            }, {
+                "id": 22,
+                "subject_index": 0,
+                "visit_index": 0,
+                "group_index": 0,
+                "form_version": 2,
+                "updated_at": "2026-02-01T00:00:00Z",
+                "data": {"section": {"temperature": 36.7, "notes": "Initial note"}},
+            }]
+
+    common = {"_id": "temperature", "name": "temperature", "label": "Temperature", "type": "number"}
+    notes = {"_id": "notes", "name": "notes", "label": "Notes", "type": "textarea"}
+
+    def schema(fields):
+        return {
+            "subjects": [{"id": "SUBJ-A", "group": "Control"}],
+            "visits": [{"name": "Baseline"}],
+            "groups": [{"name": "Control"}],
+            "selectedModels": [{"_id": "section", "title": "Assessment", "fields": fields}],
+        }
+
+    schema_v1 = schema([common, notes])
+    schema_v2 = schema([common])
+    archive, _ = build_analysis_export(
+        repo=NotesRemovedRepo(tmp_path),
+        study_id=4,
+        study_name="Notes Removed Study",
+        study_data=schema_v2,
+        schemas_by_version={1: schema_v1, 2: schema_v2},
+        options=ExportOptions(versions={1, 2}, include_files=False),
+    )
+
+    with zipfile.ZipFile(archive) as bundle:
+        root = "study-4-notes-removed-study_bids-export/"
+        lines = bundle.read(root + "phenotype/ecrf.tsv").decode().splitlines()
+        headers = lines[0].split("\t")
+        values = dict(zip(headers, lines[1].split("\t")))
+        assert headers == ["participant_id", "visit", "group", "temperature", "notes__v001", "notes__v002"]
+        assert values["temperature"] == "36.7"
+        assert values["notes__v001"] == "Initial note"
+        assert values["notes__v002"] == "n/a"

--- a/tests/test_study_export.py
+++ b/tests/test_study_export.py
@@ -1,0 +1,108 @@
+import json
+import zipfile
+from pathlib import Path
+from types import SimpleNamespace
+
+from eCRF_backend.study_export import ExportOptions, build_analysis_export
+
+
+class FakeRepo:
+    def __init__(self, root: Path):
+        self.root = root
+        self.dataset = root / "dataset"
+        self.audit_study = self.dataset / "canonical" / "audit" / "system" / "study"
+        self.audit_subject = self.dataset / "canonical" / "audit" / "subject"
+        self.dataset.mkdir(parents=True)
+
+    def paths(self, study_id, study_name):
+        return SimpleNamespace(
+            dataset_path=self.dataset,
+            audit_system_study_dir=self.audit_study,
+            audit_subject_dir=self.audit_subject,
+        )
+
+    def list_entries(self, study_id, study_name):
+        return [
+            {
+                "id": 1,
+                "subject_index": 0,
+                "visit_index": 0,
+                "group_index": 0,
+                "form_version": 2,
+                "updated_at": "2026-01-01T00:00:00Z",
+                "data": {"a-section-uuid": {"a-field-uuid": 72}},
+            },
+            {
+                "id": 2,
+                "subject_index": 1,
+                "visit_index": 0,
+                "group_index": 1,
+                "form_version": 2,
+                "updated_at": "2026-01-01T00:00:00Z",
+                "data": {"a-section-uuid": {"a-field-uuid": 65}},
+            },
+        ]
+
+    def list_files(self, study_id, study_name):
+        return []
+
+
+def _schema():
+    return {
+        "subjects": [{"id": "SUBJ-A", "group": "Control"}, {"id": "SUBJ-B", "group": "Treatment"}],
+        "visits": [{"name": "Baseline"}],
+        "groups": [{"name": "Control"}, {"name": "Treatment"}],
+        "selectedModels": [{
+            "_id": "a-section-uuid",
+            "title": "Vitals",
+            "fields": [{"_id": "a-field-uuid", "name": "heart_rate", "label": "Heart rate", "type": "number"}],
+        }],
+    }
+
+
+def test_bids_export_has_required_root_files_and_human_columns(tmp_path):
+    repo = FakeRepo(tmp_path)
+    archive, _ = build_analysis_export(
+        repo=repo,
+        study_id=4,
+        study_name="Heart Study",
+        study_data=_schema(),
+        schemas_by_version={2: _schema()},
+        options=ExportOptions(versions={2}),
+    )
+
+    with zipfile.ZipFile(archive) as bundle:
+        root = "study-4-heart-study_bids-export/"
+        names = set(bundle.namelist())
+        assert root + "dataset_description.json" in names
+        assert root + "participants.tsv" in names
+        assert root + "phenotype/ecrf_version_002.tsv" in names
+        description = json.loads(bundle.read(root + "dataset_description.json"))
+        assert description["DatasetType"] == "raw"
+        table = bundle.read(root + "phenotype/ecrf_version_002.tsv").decode()
+        participants = bundle.read(root + "participants.tsv").decode()
+        assert "heart_rate" in table
+        assert "a-field-uuid" not in table
+        assert "sub-SUBJA" in table
+        assert "subject_name" not in table.splitlines()[0]
+        assert participants.splitlines()[0] == "participant_id\tgroup"
+
+
+def test_subject_scope_filters_participants_and_entries(tmp_path):
+    repo = FakeRepo(tmp_path)
+    archive, _ = build_analysis_export(
+        repo=repo,
+        study_id=4,
+        study_name="Heart Study",
+        study_data=_schema(),
+        schemas_by_version={2: _schema()},
+        options=ExportOptions(versions={2}, subject_indexes={1}, include_audit=True),
+    )
+
+    with zipfile.ZipFile(archive) as bundle:
+        root = "study-4-heart-study_bids-export/"
+        participants = bundle.read(root + "participants.tsv").decode()
+        table = bundle.read(root + "phenotype/ecrf_version_002.tsv").decode()
+        assert "sub-SUBJB" in participants and "sub-SUBJA" not in participants
+        assert "sub-SUBJB" in table and "sub-SUBJA" not in table
+        assert root + "sourcedata/case-e/audit_log.jsonl" in bundle.namelist()

--- a/tests/test_study_export.py
+++ b/tests/test_study_export.py
@@ -13,6 +13,11 @@ class FakeRepo:
         self.audit_study = self.dataset / "canonical" / "audit" / "system" / "study"
         self.audit_subject = self.dataset / "canonical" / "audit" / "subject"
         self.dataset.mkdir(parents=True)
+        self.uploaded_file = self.dataset / "canonical" / "files" / "heart-scan.txt"
+        self.uploaded_file.parent.mkdir(parents=True)
+        self.uploaded_file.write_text("scan payload", encoding="utf-8")
+        self.study_file = self.dataset / "canonical" / "files" / "protocol.pdf"
+        self.study_file.write_text("study protocol", encoding="utf-8")
 
     def paths(self, study_id, study_name):
         return SimpleNamespace(
@@ -44,7 +49,29 @@ class FakeRepo:
         ]
 
     def list_files(self, study_id, study_name):
-        return []
+        return [{
+            "id": 7,
+            "study_id": study_id,
+            "file_name": "heart-scan.txt",
+            "file_path": "canonical/files/heart-scan.txt",
+            "storage_option": "bids",
+            "subject_index": 0,
+            "visit_index": 0,
+            "group_index": 0,
+            "modalities": ["imaging"],
+            "form_version": 2,
+        }, {
+            "id": 8,
+            "study_id": study_id,
+            "file_name": "protocol.pdf",
+            "file_path": "canonical/files/protocol.pdf",
+            "storage_option": "bids",
+            "subject_index": None,
+            "visit_index": None,
+            "group_index": None,
+            "modalities": ["documents"],
+            "form_version": 2,
+        }]
 
 
 def _schema():
@@ -77,6 +104,9 @@ def test_bids_export_has_required_root_files_and_human_columns(tmp_path):
         assert root + "dataset_description.json" in names
         assert root + "participants.tsv" in names
         assert root + "phenotype/ecrf_version_002.tsv" in names
+        assert root + "sourcedata/sub-SUBJA/imaging/file-7_heart-scan.txt" in names
+        assert root + "sourcedata/study/documents/file-8_protocol.pdf" in names
+        assert root + "sourcedata/files_manifest.json" in names
         description = json.loads(bundle.read(root + "dataset_description.json"))
         assert description["DatasetType"] == "raw"
         table = bundle.read(root + "phenotype/ecrf_version_002.tsv").decode()
@@ -86,6 +116,8 @@ def test_bids_export_has_required_root_files_and_human_columns(tmp_path):
         assert "sub-SUBJA" in table
         assert "subject_name" not in table.splitlines()[0]
         assert participants.splitlines()[0] == "participant_id\tgroup"
+        assert bundle.read(root + "sourcedata/sub-SUBJA/imaging/file-7_heart-scan.txt").decode() == "scan payload"
+        assert bundle.read(root + "sourcedata/study/documents/file-8_protocol.pdf").decode() == "study protocol"
 
 
 def test_subject_scope_filters_participants_and_entries(tmp_path):
@@ -106,3 +138,32 @@ def test_subject_scope_filters_participants_and_entries(tmp_path):
         assert "sub-SUBJB" in participants and "sub-SUBJA" not in participants
         assert "sub-SUBJB" in table and "sub-SUBJA" not in table
         assert root + "sourcedata/case-e/audit_log.jsonl" in bundle.namelist()
+
+
+def test_individual_subject_folders_group_visit_data_and_modality_files(tmp_path):
+    repo = FakeRepo(tmp_path)
+    archive, _ = build_analysis_export(
+        repo=repo,
+        study_id=4,
+        study_name="Heart Study",
+        study_data=_schema(),
+        schemas_by_version={2: _schema()},
+        options=ExportOptions(
+            versions={2},
+            include_files=True,
+            include_subject_folders=True,
+        ),
+    )
+
+    with zipfile.ZipFile(archive) as bundle:
+        root = "study-4-heart-study_bids-export/"
+        subject_visit = root + "sourcedata/sub-SUBJA/ses-Baseline/"
+        names = set(bundle.namelist())
+        subject_tsv = subject_visit + "ecrf/sub-SUBJA_ses-Baseline_version-002_ecrf.tsv"
+        subject_json = subject_visit + "ecrf/sub-SUBJA_ses-Baseline_version-002_ecrf.json"
+        subject_file = subject_visit + "imaging/file-7_heart-scan.txt"
+        assert subject_tsv in names
+        assert subject_json in names
+        assert subject_file in names
+        assert "heart_rate" in bundle.read(subject_tsv).decode()
+        assert bundle.read(subject_file).decode() == "scan payload"


### PR DESCRIPTION
## Summary

- redesign the Study View export area with case-e-consistent cards, icons, and a guided download dialog
- add BIDS-compliant analysis exports with human-readable field names
- support whole-study, subject, group, visit, files-only, and audit-only downloads
- support latest, selected, and all study template versions
- include optional subject/study files, templates, and audit history
- remove redundant subject-name columns from both `participants.tsv` and phenotype TSV files

## Why

Study downloads previously offered a single raw ZIP without analysis-focused scoping or clear version/file/audit controls. The updated workflow makes the BIDS analysis export the default while retaining template and merge exports.

